### PR TITLE
chore/mike versoned docs

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -314,37 +314,73 @@ body {
   color: var(--bw-bg-root) !important;
 }
 
-/* Version selector dropdown */
+/* Version selector — floating button at bottom-right, detached from header */
+.md-header .md-version {
+  position: fixed;
+  bottom: 1.2rem;
+  right: 1.2rem;
+  z-index: 4;
+  height: 2.4rem;
+  background: var(--bw-bg-surface);
+  border-radius: 1.2rem;
+  box-shadow: var(--md-shadow-z2);
+  display: flex;
+  align-items: center;
+  padding: 0 0.4rem 0 0.8rem;
+  transition: background-color .25s, box-shadow .25s;
+}
 
-/* Hide version text — only show the arrow icon */
+.md-header .md-version:hover {
+  background: var(--bw-bg-hover);
+  box-shadow: var(--md-shadow-z3);
+}
+
+/* Dropdown list: open upward from the floating button */
+.md-header .md-version .md-version__list {
+  bottom: 100%;
+  top: auto;
+  margin-bottom: 0.4rem;
+  border-radius: 0.4rem;
+  min-width: 8rem;
+}
+
+/* Version button: arrow icon only, no text */
 .md-version__current {
-  color: #313131 !important;
+  color: var(--bw-fg-primary) !important;
   font-size: 0 !important;
-  width: 2.4rem;
+  width: auto;
   overflow: hidden;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  padding: 0 0.4rem 0 0;
+  line-height: 2.4rem;
 }
 
-/* Keep the :after arrow visible */
+.md-version__current:hover {
+  color: var(--bw-accent-orange) !important;
+  text-decoration: none !important;
+}
+
+/* Arrow icon via :after */
 .md-version__current:after {
-  font-size: .8rem;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0;
 }
 
+/* Hide alias */
 .md-version__alias {
   display: none !important;
 }
 
-.md-version__current:hover {
-  color: #313131 !important;
-  text-decoration: underline !important;
-  text-decoration-color: var(--bw-accent-orange) !important;
-}
-
+/* Dropdown items */
 .md-version__item .md-version__link {
-  color: var(--bw-accent-orange) !important;
+  color: var(--bw-fg-primary) !important;
 }
 
 .md-version__item .md-version__link:hover {
   color: var(--bw-accent-orange) !important;
-  text-decoration: underline !important;
-  text-decoration-color: var(--bw-accent-orange) !important;
+  background: var(--bw-bg-hover);
+  text-decoration: none !important;
 }

--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -344,12 +344,9 @@ body {
   min-width: 8rem;
 }
 
-/* Version button: arrow icon only, no text */
+/* Version button: show version name in orange, with arrow icon */
 .md-version__current {
-  color: var(--bw-fg-primary) !important;
-  font-size: 0 !important;
-  width: auto;
-  overflow: hidden;
+  color: var(--bw-accent-orange) !important;
   cursor: pointer;
   background: transparent;
   border: 0;
@@ -358,15 +355,8 @@ body {
 }
 
 .md-version__current:hover {
-  color: var(--bw-accent-orange) !important;
+  color: var(--bw-accent-yellow-strong) !important;
   text-decoration: none !important;
-}
-
-/* Arrow icon via :after */
-.md-version__current:after {
-  display: inline-block;
-  vertical-align: middle;
-  margin-left: 0;
 }
 
 /* Hide alias */
@@ -376,11 +366,12 @@ body {
 
 /* Dropdown items */
 .md-version__item .md-version__link {
-  color: var(--bw-fg-primary) !important;
+  color: var(--bw-accent-orange) !important;
 }
 
-.md-version__item .md-version__link:hover {
-  color: var(--bw-accent-orange) !important;
+.md-version__item .md-version__link:hover,
+.md-version__item .md-version__link:focus {
+  color: var(--bw-accent-yellow-strong) !important;
   background: var(--bw-bg-hover);
   text-decoration: none !important;
 }

--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -315,8 +315,22 @@ body {
 }
 
 /* Version selector dropdown */
+
+/* Hide version text — only show the arrow icon */
 .md-version__current {
   color: #313131 !important;
+  font-size: 0 !important;
+  width: 2.4rem;
+  overflow: hidden;
+}
+
+/* Keep the :after arrow visible */
+.md-version__current:after {
+  font-size: .8rem;
+}
+
+.md-version__alias {
+  display: none !important;
 }
 
 .md-version__current:hover {

--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -314,64 +314,119 @@ body {
   color: var(--bw-bg-root) !important;
 }
 
-/* Version selector — floating button at bottom-right, detached from header */
+/* HIDE MIKE'S BUILT-IN VERSION SELECTOR — using custom dropdown instead */
 .md-header .md-version {
-  position: fixed;
-  bottom: 1.2rem;
-  right: 1.2rem;
-  z-index: 4;
-  height: 2.4rem;
-  background: var(--bw-bg-surface);
-  border-radius: 1.2rem;
-  box-shadow: var(--md-shadow-z2);
-  display: flex;
-  align-items: center;
-  padding: 0 0.4rem 0 0.8rem;
-  transition: background-color .25s, box-shadow .25s;
-}
-
-.md-header .md-version:hover {
-  background: var(--bw-bg-hover);
-  box-shadow: var(--md-shadow-z3);
-}
-
-/* Dropdown list: open upward from the floating button */
-.md-header .md-version .md-version__list {
-  bottom: 100%;
-  top: auto;
-  margin-bottom: 0.4rem;
-  border-radius: 0.4rem;
-  min-width: 8rem;
-}
-
-/* Version button: show version name in orange, with arrow icon */
-.md-version__current {
-  color: var(--bw-accent-orange) !important;
-  cursor: pointer;
-  background: transparent;
-  border: 0;
-  padding: 0 0.4rem 0 0;
-  line-height: 2.4rem;
-}
-
-.md-version__current:hover {
-  color: var(--bw-accent-yellow-strong) !important;
-  text-decoration: none !important;
-}
-
-/* Hide alias */
-.md-version__alias {
   display: none !important;
 }
 
-/* Dropdown items */
-.md-version__item .md-version__link {
-  color: var(--bw-accent-orange) !important;
+/* Django-style version dropdown — floating button at bottom-right */
+.django-version-dropdown {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 1000;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
-.md-version__item .md-version__link:hover,
-.md-version__item .md-version__link:focus {
-  color: var(--bw-accent-yellow-strong) !important;
+.django-version-dropdown__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--bw-bg-surface);
+  border: 1px solid var(--bw-border);
+  border-radius: 4px;
+  color: var(--bw-fg-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.django-version-dropdown__button:hover {
   background: var(--bw-bg-hover);
-  text-decoration: none !important;
+  border-color: var(--bw-accent-orange);
+  color: var(--bw-accent-yellow);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
+}
+
+.django-version-dropdown__button:focus {
+  outline: 2px solid var(--bw-accent-orange);
+  outline-offset: 2px;
+}
+
+.django-version-dropdown__arrow {
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+}
+
+.django-version-dropdown__button[aria-expanded="true"] .django-version-dropdown__arrow {
+  transform: rotate(180deg);
+}
+
+.django-version-dropdown__list {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 180px;
+  max-width: 280px;
+  max-height: 300px;
+  overflow-y: auto;
+  background: var(--bw-bg-surface);
+  border: 1px solid var(--bw-border);
+  border-radius: 4px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  padding: 0.5rem 0;
+  z-index: 1001;
+}
+
+.django-version-dropdown__item {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--bw-fg-primary);
+  text-decoration: none;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.django-version-dropdown__item:hover {
+  background: var(--bw-bg-hover);
+  color: var(--bw-accent-yellow);
+  text-decoration: none;
+}
+
+.django-version-dropdown__item:focus {
+  outline: none;
+  background: var(--bw-bg-hover);
+  color: var(--bw-accent-yellow);
+}
+
+.django-version-dropdown__item--current {
+  color: var(--bw-accent-orange);
+  font-weight: 600;
+}
+
+.django-version-dropdown__item--current:hover {
+  color: var(--bw-accent-yellow);
+  background: var(--bw-bg-hover);
+}
+
+/* Responsive: on mobile, make dropdown full width */
+@media only screen and (max-width: 48rem) {
+  .django-version-dropdown {
+    bottom: 1rem;
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .django-version-dropdown__list {
+    right: 0;
+    left: 0;
+    min-width: auto;
+    max-width: none;
+  }
 }

--- a/docs/assets/js/version-dropdown.js
+++ b/docs/assets/js/version-dropdown.js
@@ -10,6 +10,19 @@ window.addEventListener("DOMContentLoaded", function() {
     CURRENT_VERSION = 'latest';
   }
 
+  // Determine if we're in a versioned deployment (production) or local single build
+  var isVersionedPath = versionMatch !== null;
+  var baseUrl = isVersionedPath ? basePath.substring(0, basePath.indexOf(CURRENT_VERSION)) : '/';
+  
+  // For local development without versioned paths, link to root
+  if (!isVersionedPath) {
+    baseUrl = '/';
+  }
+
+  // In local development (no versioned paths), all version links should point to root
+  // since we only have a single build. In production (mike), versioned paths exist.
+  var isLocalDev = !isVersionedPath;
+
   function makeDropdown(versions, selected) {
     var container = document.createElement("div");
     container.className = "django-version-dropdown";
@@ -40,7 +53,8 @@ window.addEventListener("DOMContentLoaded", function() {
     versions.forEach(function(v) {
       var link = document.createElement("a");
       link.className = "django-version-dropdown__item";
-      link.href = "/" + v.version + "/";
+      // In local dev, all versions point to root since we only have one build
+      link.href = isLocalDev ? '/' : (baseUrl + v.version + "/");
       link.textContent = v.title || v.version;
       link.setAttribute("role", "option");
       if (v.version === selected) {
@@ -100,7 +114,6 @@ window.addEventListener("DOMContentLoaded", function() {
   }
 
   // Fetch versions.json
-  // Fetch versions.json from the site root
   fetch("/versions.json")
     .then(function(response) {
       if (!response.ok) throw new Error("Failed to load versions.json");

--- a/docs/assets/js/version-dropdown.js
+++ b/docs/assets/js/version-dropdown.js
@@ -1,0 +1,135 @@
+window.addEventListener("DOMContentLoaded", function() {
+  // Find the base URL from the current page
+  var basePath = window.location.pathname;
+  // Match version in path like /en/latest/, /en/dev/, /en/0.4.1/, or /latest/, /dev/
+  var versionMatch = basePath.match(/(?:\/en)?\/([^\/]+)\//);
+  var CURRENT_VERSION = versionMatch ? versionMatch[1] : 'latest';
+  
+  // For local development, we may not have a version in the path
+  if (CURRENT_VERSION === '' || CURRENT_VERSION === 'index.html' || CURRENT_VERSION === 'en') {
+    CURRENT_VERSION = 'latest';
+  }
+
+  function makeDropdown(versions, selected) {
+    var container = document.createElement("div");
+    container.className = "django-version-dropdown";
+    container.id = "django-version-dropdown";
+    
+    var button = document.createElement("button");
+    button.className = "django-version-dropdown__button";
+    button.type = "button";
+    button.setAttribute("aria-haspopup", "listbox");
+    button.setAttribute("aria-expanded", "false");
+    
+    var versionText = document.createElement("span");
+    versionText.className = "django-version-dropdown__text";
+    versionText.textContent = "Documentation version: " + selected;
+    
+    var arrow = document.createElement("span");
+    arrow.className = "django-version-dropdown__arrow";
+    arrow.innerHTML = "▼";
+    
+    button.appendChild(versionText);
+    button.appendChild(arrow);
+    
+    var dropdown = document.createElement("div");
+    dropdown.className = "django-version-dropdown__list";
+    dropdown.setAttribute("role", "listbox");
+    dropdown.style.display = "none";
+    
+    versions.forEach(function(v) {
+      var link = document.createElement("a");
+      link.className = "django-version-dropdown__item";
+      link.href = "/" + v.version + "/";
+      link.textContent = v.title || v.version;
+      link.setAttribute("role", "option");
+      if (v.version === selected) {
+        link.classList.add("django-version-dropdown__item--current");
+        link.setAttribute("aria-selected", "true");
+      } else {
+        link.setAttribute("aria-selected", "false");
+      }
+      dropdown.appendChild(link);
+    });
+    
+    container.appendChild(button);
+    container.appendChild(dropdown);
+    
+    // Toggle dropdown on button click
+    button.addEventListener("click", function(e) {
+      e.stopPropagation();
+      var isOpen = dropdown.style.display === "block";
+      dropdown.style.display = isOpen ? "none" : "block";
+      button.setAttribute("aria-expanded", !isOpen);
+    });
+    
+    // Close dropdown when clicking outside
+    document.addEventListener("click", function(e) {
+      if (!container.contains(e.target)) {
+        dropdown.style.display = "none";
+        button.setAttribute("aria-expanded", "false");
+      }
+    });
+    
+    // Handle keyboard navigation
+    button.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") {
+        dropdown.style.display = "none";
+        button.setAttribute("aria-expanded", "false");
+        button.focus();
+      } else if (e.key === "ArrowDown" && dropdown.style.display === "none") {
+        e.preventDefault();
+        dropdown.style.display = "block";
+        button.setAttribute("aria-expanded", "true");
+        dropdown.querySelector("a").focus();
+      }
+    });
+    
+    dropdown.addEventListener("keydown", function(e) {
+      if (e.key === "Escape") {
+        dropdown.style.display = "none";
+        button.setAttribute("aria-expanded", "false");
+        button.focus();
+      } else if (e.key === "ArrowUp" && e.target === dropdown.querySelector("a")) {
+        e.preventDefault();
+        button.focus();
+      }
+    });
+    
+    return container;
+  }
+
+  // Fetch versions.json
+  // Fetch versions.json from the site root
+  fetch("/versions.json")
+    .then(function(response) {
+      if (!response.ok) throw new Error("Failed to load versions.json");
+      return response.json();
+    })
+    .then(function(versions) {
+      // Filter out hidden versions if present
+      var visibleVersions = versions.filter(function(v) {
+        return !v.properties || !v.properties.hidden;
+      });
+      
+      // Find the real version - prioritize exact version match over alias
+      var realVersionObj = versions.find(function(v) {
+        return v.version === CURRENT_VERSION;
+      });
+      // If no exact match, check aliases
+      if (!realVersionObj) {
+        realVersionObj = versions.find(function(v) {
+          return v.aliases && v.aliases.includes(CURRENT_VERSION);
+        });
+      }
+      var realVersion = realVersionObj ? realVersionObj.version : CURRENT_VERSION;
+      
+      var dropdown = makeDropdown(visibleVersions, realVersion);
+      
+      // Insert at bottom-right of page (fixed position)
+      document.body.appendChild(dropdown);
+    })
+    .catch(function(err) {
+      console.warn("Version dropdown: Could not load versions.json", err);
+    });
+});

--- a/docs/reference/foundation.md
+++ b/docs/reference/foundation.md
@@ -211,6 +211,80 @@ In practice, you can import `ValueObject` from either
 or from `forging_blocks.domain.value_object` (the re-export). It is not
 re-exported from the top-level `forging_blocks.foundation` namespace.
 
+#### Why ValueObject over a frozen dataclass?
+
+Python's `@dataclass(frozen=True)` and `ValueObject` both produce immutable
+objects, but they differ in a critical way: **when immutability kicks in**.
+
+| Mechanism | Freeze timing | Can set attrs in `__init__`? | Equality / hashing |
+|---|---|---|---|
+| `@dataclass(frozen=True)` | Before `__init__` runs | ❌ Must use `object.__setattr__` in `__post_init__` | Based on all fields (automatic) |
+| `ValueObject` (`@auto_freeze`) | **After** `__init__` completes | ✅ Natural `self._x = x` works | Based on `_equality_components` (explicit, selective) |
+
+**Frozen dataclass** prevents *all* `__setattr__` from the moment the object is
+created, including inside `__init__`. Any validation or transformation during
+initialization must work around this by calling `object.__setattr__`, which is
+verbose and error-prone:
+
+```python
+@dataclass(frozen=True)
+class Email:
+    value: str
+
+    def __post_init__(self):
+        if "@" not in self.value:
+            raise ValueError("Invalid email")
+        # Already frozen — self.value = ... would raise FrozenInstanceError
+        # Must use object.__setattr__ for any transformation:
+        object.__setattr__(self, "value", self.value.lower().strip())
+```
+
+**ValueObject** keeps the instance mutable during `__init__`, so you can
+validate, transform, and assign attributes naturally. Immutability is
+enforced *after* construction via `@auto_freeze`:
+
+```python
+class Email(ValueObject[str]):
+    __slots__ = ("_value",)
+
+    def __init__(self, value: str) -> None:
+        super().__init__()
+        if "@" not in value:
+            raise ValueError("Invalid email format")
+        self._value = value.lower().strip()  # Natural assignment
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    @property
+    def _equality_components(self) -> tuple[Hashable, ...]:
+        return (self._value,)
+```
+
+Beyond timing, `ValueObject` gives you **four things for free** that a frozen
+dataclass requires manual wiring for:
+
+1. **Auto-freeze** — `@auto_freeze` is applied automatically, so every concrete
+   subclass becomes immutable with zero boilerplate.
+2. **Equality** — you control exactly which fields participate via
+   `_equality_components`, rather than relying on all fields automatically.
+3. **Hashing** — derived from the same components as equality.
+4. **Domain-appropriate error** — raises `CantModifyImmutableAttributeError`
+   instead of the generic `FrozenInstanceError`.
+
+**When to use each:**
+
+- Use `ValueObject` when you need domain semantics: selective equality,
+  natural `__init__` with validation, and a domain-specific error type.
+  This covers the vast majority of domain modeling.
+- Use `@dataclass(frozen=True)` when you need a simple, throwaway data holder
+  where all-field equality is acceptable and you don't need validation
+  during construction.
+- Use `@auto_freeze` directly on a dataclass or plain class when you want
+  post-init immutability but don't need the value-object semantics
+  (equality components, hash, etc.).
+
 ---
 
 ### Auto-freeze

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,20 @@
+[
+  {
+    "version": "latest",
+    "title": "latest",
+    "aliases": ["dev"],
+    "is_default": true
+  },
+  {
+    "version": "dev",
+    "title": "dev",
+    "aliases": [],
+    "is_default": false
+  },
+  {
+    "version": "0.4.1",
+    "title": "0.4.1",
+    "aliases": [],
+    "is_default": false
+  }
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,10 +11,9 @@ extra_css:
   - assets/css/theme.css
   - assets/css/mermaid-theme.css
 
-extra:
-  version:
-    provider: mike
-    default: latest  # Set which version is the default landing page
+extra_javascript:
+  - assets/js/version-dropdown.js
+  - assets/js/mermaid-init.js
 
 theme:
   name: material
@@ -164,6 +163,9 @@ plugins:
   - search
   - autorefs
   - section-index
+  - mike:
+      alias_type: symlink
+      version_selector: true
   - mkdocstrings:
       handlers:
         python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ extra_css:
 extra:
   version:
     provider: mike
+    default: latest  # Set which version is the default landing page
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,10 @@ extra_css:
   - assets/css/theme.css
   - assets/css/mermaid-theme.css
 
+extra:
+  version:
+    provider: mike
+
 theme:
   name: material
   language: en
@@ -74,7 +78,71 @@ nav:
       - Infrastructure: reference/infrastructure.md
       - Presentation: reference/presentation.md
       - Testing: reference/testing.md
-
+      - API Reference:
+        - Application:
+          - Errors:
+            - Unit Of Work Error: reference/autodoc/application/errors/unit_of_work_error.md
+          - Ports / Inbound:
+            - Message Handler: reference/autodoc/application/ports/inbound/message_handler.md
+            - Use Case: reference/autodoc/application/ports/inbound/use_case.md
+          - Ports / Outbound:
+            - Command Sender: reference/autodoc/application/ports/outbound/command_sender.md
+            - Event Publisher: reference/autodoc/application/ports/outbound/event_publisher.md
+            - Message Bus: reference/autodoc/application/ports/outbound/message_bus.md
+            - Notifier: reference/autodoc/application/ports/outbound/notifier.md
+            - Query Fetcher: reference/autodoc/application/ports/outbound/query_fetcher.md
+            - Repository: reference/autodoc/application/ports/outbound/repository.md
+            - Unit Of Work: reference/autodoc/application/ports/outbound/unit_of_work.md
+        - Domain:
+          - Entity: reference/autodoc/domain/entity.md
+          - Value Object: reference/autodoc/domain/value_object.md
+          - Aggregate Root:
+            - Aggregate Root: reference/autodoc/domain/aggregate_root/aggregate_root.md
+            - Aggregate Version: reference/autodoc/domain/aggregate_root/aggregate_version.md
+          - Errors:
+            - Draft Entity Is Not Hashable Error: reference/autodoc/domain/errors/draft_entity_is_not_hashable_error.md
+            - Entity Id None Error: reference/autodoc/domain/errors/entity_id_none_error.md
+        - Foundation:
+          - Debuggable: reference/autodoc/foundation/debuggable.md
+          - Identified: reference/autodoc/foundation/identified.md
+          - Mapper: reference/autodoc/foundation/mapper.md
+          - Ports: reference/autodoc/foundation/ports.md
+          - Value Object: reference/autodoc/foundation/value_object.md
+          - Autofreeze:
+            - Auto Freeze: reference/autodoc/foundation/autofreeze/auto_freeze.md
+            - Supports Auto Freeze: reference/autodoc/foundation/autofreeze/supports_auto_freeze.md
+          - Errors:
+            - Cant Modify Immutable Attribute Error: reference/autodoc/foundation/errors/cant_modify_immutable_attribute_error.md
+            - Combined Errors: reference/autodoc/foundation/errors/combined_errors.md
+            - Core: reference/autodoc/foundation/errors/core.md
+            - Error: reference/autodoc/foundation/errors/error.md
+            - Field Errors: reference/autodoc/foundation/errors/field_errors.md
+            - None Not Allowed Error: reference/autodoc/foundation/errors/none_not_allowed_error.md
+            - Result Access Error: reference/autodoc/foundation/errors/result_access_error.md
+            - Rule Violation Error: reference/autodoc/foundation/errors/rule_violation_error.md
+            - Validation Error: reference/autodoc/foundation/errors/validation_error.md
+          - Messages:
+            - Command: reference/autodoc/foundation/messages/command.md
+            - Event: reference/autodoc/foundation/messages/event.md
+            - Message: reference/autodoc/foundation/messages/message.md
+            - Query: reference/autodoc/foundation/messages/query.md
+          - Meta:
+            - Final Abc Meta: reference/autodoc/foundation/meta/final_abc_meta.md
+            - Final Meta: reference/autodoc/foundation/meta/final_meta.md
+          - Result:
+            - Err: reference/autodoc/foundation/result/err.md
+            - Ok: reference/autodoc/foundation/result/ok.md
+            - Result: reference/autodoc/foundation/result/result.md
+        - Infrastructure:
+          - Errors:
+            - Repository Errors: reference/autodoc/infrastructure/errors/repository_errors.md
+          - Message Bus:
+            - In Memory Message Bus: reference/autodoc/infrastructure/message_bus/in_memory_message_bus.md
+          - Repositories:
+            - In Memory Read Repository: reference/autodoc/infrastructure/repositories/in_memory_read_repository.md
+            - In Memory Write Repository: reference/autodoc/infrastructure/repositories/in_memory_write_repository.md
+          - Unit Of Work:
+            - In Memory Unit Of Work: reference/autodoc/infrastructure/unit_of_work/in_memory_unit_of_work.md
   - Architectural Styles:
       - Overview: architectural-styles/index.md
       - Clean Architecture: architectural-styles/clean-architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,18 +173,15 @@ test = { env = { "RUN_GITHUB_CLI_TESTS" = "1", "RUN_E2E_TESTS" = "1" }, cmd = "p
 "test:debug" = "pytest -x -vvv -s"
 
 "docs:generate" = { cmd = "python scripts/generate_autodoc_pages.py" }
-"docs:build".sequence = [
-  "docs:generate",
-  { cmd = "poetry run mkdocs build --strict" }
-]
-"docs:serve".sequence = [
-  "docs:generate",
-  { cmd = "poetry run mike deploy dev" },
-  { cmd = "poetry run mike serve" }
-]
-"docs:serve-versioned" = { cmd = "poetry run mike serve" }
-"docs:deploy-version" = { cmd = "bash scripts/deploy_versioned_docs.sh" }
-"docs:list-versions" = { cmd = "poetry run mike list" }
+
+"docs:build" = { cmd = "python scripts/generate_autodoc_pages.py && poetry run mkdocs build --strict" }
+
+"docs:serve" = { shell = "python scripts/generate_autodoc_pages.py && poetry run mike serve" }
+"docs:deploy:dev" = { cmd = "poetry run poe docs:generate && poetry run mike deploy --push --update-aliases dev latest" }
+
+"docs:deploy:release" = { cmd = "poetry run poe docs:generate && poetry run mike deploy --push $(poetry version -s)" }
+
+"docs:versions" = { cmd = "poetry run mike list" }
 
 "ci:check".sequence = [
   "lint:shell",

--- a/src/forging_blocks/foundation/autofreeze/supports_auto_freeze.py
+++ b/src/forging_blocks/foundation/autofreeze/supports_auto_freeze.py
@@ -10,19 +10,104 @@ class SupportsAutoFreeze(Protocol):  # pragma: no cover
     immutable states. The @auto_freeze decorator calls these methods
     based on class configuration.
 
-    Example:
+    **Traditional class** — the simplest use case: a plain Python class
+    that becomes immutable after ``__init__``:
+
         ```python
+        from forging_blocks.foundation.autofreeze import auto_freeze
+        from forging_blocks.foundation.errors import (
+            CantModifyImmutableAttributeError,
+        )
+
         @auto_freeze
-        class Email(ValueObject[str]):
+        class Money:
+            def __init__(self, amount: int, currency: str) -> None:
+                if amount < 0:
+                    raise ValueError("Amount cannot be negative")
+                self._amount = amount
+                self._currency = currency
+
             def freeze_instance(self) -> None:
-                object.__setattr__(self, "_Email__is_frozen", True)
+                object.__setattr__(self, "_Money__frozen", True)
 
             def unfreeze_instance(self) -> None:
-                object.__setattr__(self, "_Email__is_frozen", False)
+                object.__setattr__(self, "_Money__frozen", False)
 
             @classmethod
             def should_use_internal_freezing(cls) -> bool:
                 return True
+
+            def __setattr__(self, name: str, value: object) -> None:
+                if getattr(self, "_Money__frozen", False):
+                    raise CantModifyImmutableAttributeError(
+                        class_name=self.__class__.__name__,
+                        attribute_name=name,
+                    )
+                object.__setattr__(self, name, value)
+        ```
+
+    **Regular dataclass** — ``@auto_freeze`` adds post-init immutability
+    to a dataclass that otherwise allows mutation:
+
+        ```python
+        from dataclasses import dataclass
+
+        from forging_blocks.foundation.autofreeze import auto_freeze
+        from forging_blocks.foundation.errors import (
+            CantModifyImmutableAttributeError,
+        )
+
+        @auto_freeze
+        @dataclass
+        class Point:
+            x: float
+            y: float
+
+            def freeze_instance(self) -> None:
+                object.__setattr__(self, "_Point__frozen", True)
+
+            def unfreeze_instance(self) -> None:
+                object.__setattr__(self, "_Point__frozen", False)
+
+            @classmethod
+            def should_use_internal_freezing(cls) -> bool:
+                return True
+
+            def __setattr__(self, name: str, value: object) -> None:
+                if getattr(self, "_Point__frozen", False):
+                    raise CantModifyImmutableAttributeError(
+                        class_name=self.__class__.__name__,
+                        attribute_name=name,
+                    )
+                object.__setattr__(self, name, value)
+        ```
+
+    **Frozen dataclass** — when combined with ``@dataclass(frozen=True)``,
+    the decorator still calls ``freeze_instance`` after init, but
+    immutability is already enforced by the dataclass machinery.
+    ``@auto_freeze`` is generally redundant here unless you need
+    ``unfreeze_instance`` for test tooling:
+
+        ```python
+        from dataclasses import dataclass
+
+        from forging_blocks.foundation.autofreeze import auto_freeze
+
+        @auto_freeze
+        @dataclass(frozen=True)
+        class ImmutablePoint:
+            x: float
+            y: float
+
+            def freeze_instance(self) -> None:
+                pass  # frozen=True already prevents mutation
+
+            def unfreeze_instance(self) -> None:
+                pass
+
+            @classmethod
+            def should_use_internal_freezing(cls) -> bool:
+                return False  # already frozen, no extra work needed
         ```
     """
 


### PR DESCRIPTION
- **docs(foundation): replace circular SupportsAutoFreeze example with traditional class, regular dataclass, and frozen dataclass examples**
- **docs(foundation): explain why ValueObject over frozen dataclass — freeze timing, natural __init__, selective equality**
- **style(docs): hide version text in selector dropdown, show only arrow icon to prevent header layout overlap**
- **style(docs): detach version selector from header, float at bottom-right as compact arrow-only button**
- **fix(docs): add extra.version.provider mike config so version selector renders in Material theme**
- **docs(assets): version visual aesthetics**
- **chore(mkdocs): default versions is latest**
- **chore(pyproject): poe tasks for mkdocs mike plugin**
- **refactor(docs): remove top-most version-dropdown**
- **feat(docs): impl version-dropdown**
- **feat(docs/assets): impl version-dropdown.js**
- **chore(mkdocs): add mike config and js for versioned documentation**
- **chore(docs): versions.json created to mike versioned docs**
