### PR TITLE
fix(docs): use relative path for versions.json fetch

### DIFF
--- a/docs/assets/js/version-dropdown.js
+++ b/docs/assets/js/version-dropdown.js
@@ -114,7 +114,7 @@ window.addEventListener("DOMContentLoaded", function() {
   }
 
   // Fetch versions.json
-  fetch("/versions.json")
+  fetch("versions.json")
     .then(function(response) {
       if (!response.ok) throw new Error("Failed to load versions.json");
       return response.json();


### PR DESCRIPTION
/versions.json breaks on GitHub Pages when the site is served
from a subdirectory (/forging-blocks/).  A plain relative path
resolves correctly everywhere: root page, versioned pages, and
local development.
