### PR TITLE
chore/modernize generics

### DIFF
--- a/src/forging_blocks/application/ports/inbound/message_handler.py
+++ b/src/forging_blocks/application/ports/inbound/message_handler.py
@@ -16,7 +16,7 @@ Non-Responsibilities:
     - Persistence (handled by repositories).
 """
 
-from typing import Any, Generic, Protocol, TypeAlias, TypeVar
+from typing import Any, Protocol, TypeAlias, TypeVar
 
 from forging_blocks.foundation.messages.command import Command
 from forging_blocks.foundation.messages.event import Event
@@ -24,17 +24,13 @@ from forging_blocks.foundation.messages.message import Message
 from forging_blocks.foundation.messages.query import Query
 from forging_blocks.foundation.ports import InboundPort
 
-MessageType = TypeVar("MessageType", contravariant=True, bound=Message[Any])
-MessageHandlerResultType = TypeVar("MessageHandlerResultType", covariant=True)
-QueryResultType = TypeVar("QueryResultType", covariant=True)
 CommandType = TypeVar("CommandType", contravariant=True, bound=Command[Any])
-CommandResultType = TypeVar("CommandResultType", covariant=True)
-EventType = TypeVar("EventType", contravariant=True, bound=Event[Any])
 QueryType = TypeVar("QueryType", contravariant=True, bound=Query)
+EventType = TypeVar("EventType", contravariant=True, bound=Event[Any])
+QueryResultType = TypeVar("QueryResultType", covariant=True)
 
 
-class MessageHandler(
-    Generic[MessageType, MessageHandlerResultType],
+class MessageHandler[MessageType: Message[Any], MessageHandlerResultType](
     InboundPort[MessageType, MessageHandlerResultType],
     Protocol,
 ):

--- a/src/forging_blocks/application/ports/inbound/use_case.py
+++ b/src/forging_blocks/application/ports/inbound/use_case.py
@@ -15,16 +15,12 @@ Non-Responsibilities:
     - UI or framework-specific concerns.
 """
 
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 from forging_blocks.foundation.ports import InboundPort
 
-RequestType = TypeVar("RequestType", contravariant=True)
-ResponseType = TypeVar("ResponseType", covariant=True)
 
-
-class UseCase(
-    Generic[RequestType, ResponseType],
+class UseCase[RequestType, ResponseType](
     InboundPort[RequestType, ResponseType],
     Protocol,
 ):

--- a/src/forging_blocks/application/ports/outbound/message_bus.py
+++ b/src/forging_blocks/application/ports/outbound/message_bus.py
@@ -14,16 +14,12 @@ Non-Responsibilities:
     - Delivery guarantees (up to infrastructure).
 """
 
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 from forging_blocks.foundation import OutboundPort
 
-MessageType = TypeVar("MessageType", contravariant=True)
-MessageBusResultType = TypeVar("MessageBusResultType", covariant=True)
 
-
-class MessageBus(
-    Generic[MessageType, MessageBusResultType],
+class MessageBus[MessageType, MessageBusResultType](
     OutboundPort[MessageType, MessageBusResultType],
     Protocol,
 ):

--- a/src/forging_blocks/application/ports/outbound/notifier.py
+++ b/src/forging_blocks/application/ports/outbound/notifier.py
@@ -12,14 +12,15 @@ Non-Responsibilities:
     - Implement retries or throttling unless defined by infrastructure.
 """
 
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 from forging_blocks.foundation.ports import OutboundPort
 
-NotificationType = TypeVar("NotificationType", contravariant=True)
 
-
-class Notifier(OutboundPort[NotificationType, None], Generic[NotificationType], Protocol):
+class Notifier[NotificationType](
+    OutboundPort[NotificationType, None],
+    Protocol,
+):
     """Outbound port for sending asynchronous notifications.
 
     Implementers integrate with concrete notification systems. The

--- a/src/forging_blocks/application/ports/outbound/query_fetcher.py
+++ b/src/forging_blocks/application/ports/outbound/query_fetcher.py
@@ -13,16 +13,14 @@ Non-Responsibilities:
     - Guarantee consistency between read and write models.
 """
 
-from typing import TypeVar
-
 from forging_blocks.application.ports.outbound.message_bus import MessageBus
 from forging_blocks.foundation.messages.query import Query
 from forging_blocks.foundation.ports import OutboundPort
 
-QueryFetcherResult = TypeVar("QueryFetcherResult", covariant=True)
 
-
-class QueryFetcher(OutboundPort[Query, QueryFetcherResult]):
+class QueryFetcher[QueryFetcherResult](
+    OutboundPort[Query, QueryFetcherResult],
+):
     """Outbound port for dispatching query messages.
 
     The QueryFetcher abstracts query execution through a MessageBus. It does

--- a/src/forging_blocks/application/ports/outbound/repository.py
+++ b/src/forging_blocks/application/ports/outbound/repository.py
@@ -16,20 +16,10 @@ Non-Responsibilities:
 
 from __future__ import annotations
 
-from typing import Generic, Protocol, Sequence, TypeVar
-
-TAggregateRoot = TypeVar("TAggregateRoot")
-TId = TypeVar("TId", contravariant=True)
-
-TReadResult = TypeVar("TReadResult", covariant=True)
-TReadAggregateRoot = TypeVar("TReadAggregateRoot", covariant=True)
-TReadId = TypeVar("TReadId", contravariant=True)
-
-TWriteAggregateRoot = TypeVar("TWriteAggregateRoot", contravariant=True)
-TWriteId = TypeVar("TWriteId", contravariant=True)
+from typing import Protocol, Sequence
 
 
-class ReadOnlyRepository(Generic[TReadAggregateRoot, TId], Protocol):
+class ReadOnlyRepository[TReadAggregateRoot, TId](Protocol):
     """Read-only repository abstraction for query operations.
 
     This interface is optimized for query-side usage in CQRS architectures.
@@ -65,7 +55,7 @@ class ReadOnlyRepository(Generic[TReadAggregateRoot, TId], Protocol):
         ...
 
 
-class WriteOnlyRepository(Protocol, Generic[TWriteAggregateRoot, TWriteId]):
+class WriteOnlyRepository[TWriteAggregateRoot, TWriteId](Protocol):
     """Write-only repository abstraction for command operations.
 
     This interface supports command-side operations where writes are applied
@@ -92,7 +82,7 @@ class WriteOnlyRepository(Protocol, Generic[TWriteAggregateRoot, TWriteId]):
         ...
 
 
-class Repository(
+class Repository[TAggregateRoot, TId](
     ReadOnlyRepository[TAggregateRoot, TId],
     WriteOnlyRepository[TAggregateRoot, TId],
     Protocol,

--- a/src/forging_blocks/domain/aggregate_root/aggregate_root.py
+++ b/src/forging_blocks/domain/aggregate_root/aggregate_root.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+
 from abc import abstractmethod
-from typing import Any, Generic, Hashable, TypeVar
+from collections.abc import Hashable
+from typing import Any
 
 from forging_blocks.domain.entity import Entity
 from forging_blocks.domain.errors.entity_id_none_error import EntityIdNoneError
@@ -12,10 +14,8 @@ from forging_blocks.foundation.messages.event import Event
 
 from .aggregate_version import AggregateVersion
 
-TId = TypeVar("TId", bound=Hashable)
 
-
-class AggregateRoot(Entity[TId], Generic[TId], metaclass=FinalABCMeta):
+class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
     """Base class for Aggregate Roots in a Domain-Driven Design context.
 
     An Aggregate Root represents the entry point for manipulating

--- a/src/forging_blocks/domain/entity.py
+++ b/src/forging_blocks/domain/entity.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
+
 from abc import ABC
 from collections.abc import Hashable
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, cast
 
 from forging_blocks.domain.errors.draft_entity_is_not_hashable_error import (
     DraftEntityIsNotHashableError,
 )
 
-TId = TypeVar("TId", bound=Hashable)
 
-
-class Entity(Generic[TId], ABC):
+class Entity[TId: Hashable](ABC):
     """Base class for all domain entities.
 
     An entity is defined by its identity rather than its attributes. Two entities with the same

--- a/src/forging_blocks/foundation/errors/combined_errors.py
+++ b/src/forging_blocks/foundation/errors/combined_errors.py
@@ -3,15 +3,13 @@
 Defines CombinedErrors which aggregates multiple Error instances into one.
 """
 
-from typing import Generic, Iterable, Iterator, Sequence, TypeVar
+from typing import Iterable, Iterator, Sequence
 
 from forging_blocks.foundation.errors.core import ErrorMessage
 from forging_blocks.foundation.errors.error import Error
 
-ErrorType = TypeVar("ErrorType", bound="Error")
 
-
-class CombinedErrors(Error, Generic[ErrorType]):
+class CombinedErrors[ErrorType: Error](Error):
     """Base class for combining multiple errors into one."""
 
     def __init__(self, errors: Iterable[ErrorType]) -> None:

--- a/src/forging_blocks/foundation/messages/message.py
+++ b/src/forging_blocks/foundation/messages/message.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Any, TypeVar
+from typing import Any
 from uuid import UUID, uuid7  # type: ignore[attr-defined]
 
 from forging_blocks.foundation.value_object import ValueObject
@@ -17,9 +17,6 @@ from forging_blocks.foundation.value_object import ValueObject
 def now() -> datetime:
     """Get the current UTC datetime."""
     return datetime.now(timezone.utc)
-
-
-MessageRawType = TypeVar("MessageRawType")
 
 
 class MessageMetadata(ValueObject[dict[str, Any]]):
@@ -158,7 +155,7 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
         return (self._message_id, self._created_at)
 
 
-class Message(ValueObject[MessageRawType], ABC):
+class Message[MessageRawType](ValueObject[MessageRawType], ABC):
     """Base class for all foundation messages.
 
     Messages are immutable value objects that represent intent or facts in the application.

--- a/src/forging_blocks/foundation/ports.py
+++ b/src/forging_blocks/foundation/ports.py
@@ -1,12 +1,9 @@
 """Foundational port definition for the ForgingBlocks."""
 
-from typing import Protocol, TypeVar
-
-InputType = TypeVar("InputType", contravariant=True)
-OutputType = TypeVar("OutputType", covariant=True)
+from typing import Protocol
 
 
-class Port(Protocol[InputType, OutputType]):  # type: ignore[reportInvalidTypeVarUse]
+class Port[InputType, OutputType](Protocol):
     """Base protocol for defining interface contracts.
 
     Port is a generic Protocol that serves as the foundation for interface
@@ -20,17 +17,17 @@ class Port(Protocol[InputType, OutputType]):  # type: ignore[reportInvalidTypeVa
     """
 
 
-class InboundPort(Port[InputType, OutputType], Protocol):  # type: ignore[reportInvalidTypeVarUse]
+class InboundPort[InputType, OutputType](Port[InputType, OutputType], Protocol):
     """Alias for Port used as an inbound marker."""
 
 
-class OutboundPort(Port[InputType, OutputType], Protocol):  # type: ignore[reportInvalidTypeVarUse]
+class OutboundPort[InputType, OutputType](Port[InputType, OutputType], Protocol):
     """Alias for Port used as an outbound marker."""
 
 
-class InputPort(InboundPort[InputType, OutputType], Protocol):  # type: ignore[reportInvalidTypeVarUse]
+class InputPort[InputType, OutputType](InboundPort[InputType, OutputType], Protocol):
     """Alias for InboundPort."""
 
 
-class OutputPort(OutboundPort[InputType, OutputType], Protocol):  # type: ignore[reportInvalidTypeVarUse]
+class OutputPort[InputType, OutputType](OutboundPort[InputType, OutputType], Protocol):
     """Alias for OutboundPort."""

--- a/src/forging_blocks/infrastructure/message_bus/in_memory_message_bus.py
+++ b/src/forging_blocks/infrastructure/message_bus/in_memory_message_bus.py
@@ -8,17 +8,13 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, cast
 
 from forging_blocks.application.ports.outbound.message_bus import MessageBus
 from forging_blocks.foundation.messages.message import Message
 
-MessageType = TypeVar("MessageType", bound=Message[Any], contravariant=True)
-MessageBusResultType = TypeVar("MessageBusResultType", covariant=True)
 
-
-class InMemoryMessageBus(
-    Generic[MessageType, MessageBusResultType],
+class InMemoryMessageBus[MessageType: Message[Any], MessageBusResultType](
     MessageBus[MessageType, MessageBusResultType],
 ):
     """In-memory message bus that routes messages to registered handlers.

--- a/src/forging_blocks/infrastructure/repositories/in_memory_read_repository.py
+++ b/src/forging_blocks/infrastructure/repositories/in_memory_read_repository.py
@@ -6,17 +6,12 @@ dictionary for query-side operations in CQRS architectures.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Generic, Sequence, TypeVar
+from collections.abc import Mapping, Sequence
 
 from forging_blocks.application.ports.outbound.repository import ReadOnlyRepository
 
-TReadAggregateRoot = TypeVar("TReadAggregateRoot")
-TId = TypeVar("TId")
 
-
-class InMemoryReadRepository(
-    Generic[TReadAggregateRoot, TId],
+class InMemoryReadRepository[TReadAggregateRoot, TId](
     ReadOnlyRepository[TReadAggregateRoot, TId],
 ):
     """In-memory implementation of ReadOnlyRepository for query operations.

--- a/src/forging_blocks/infrastructure/repositories/in_memory_write_repository.py
+++ b/src/forging_blocks/infrastructure/repositories/in_memory_write_repository.py
@@ -6,7 +6,8 @@ dictionary for command-side operations in CQRS architectures.
 
 from __future__ import annotations
 
-from typing import Any, Generic, MutableMapping, TypeVar, cast
+from collections.abc import MutableMapping
+from typing import Any, cast
 
 from forging_blocks.application.ports.outbound.repository import WriteOnlyRepository
 from forging_blocks.foundation.errors.core import ErrorMessage
@@ -16,12 +17,8 @@ from forging_blocks.infrastructure.errors.repository_errors import (
     RepositoryNotFoundError,
 )
 
-TWriteAggregateRoot = TypeVar("TWriteAggregateRoot", bound=Identified[Any])
-TWriteId = TypeVar("TWriteId")
 
-
-class InMemoryWriteRepository(
-    Generic[TWriteAggregateRoot, TWriteId],
+class InMemoryWriteRepository[TWriteAggregateRoot: Identified[Any], TWriteId](
     WriteOnlyRepository[TWriteAggregateRoot, TWriteId],
 ):
     """In-memory implementation of WriteOnlyRepository for command operations.


### PR DESCRIPTION
- **refactor(foundation): replace TypeVar and Generic with PEP 695 type parameters**
- **refactor(foundation): migrate port protocols to PEP 695 type parameters**
- **refactor(foundation): replace TypeVar and Generic with PEP 695 type parameters**
- **refactor(domain): replace TypeVar and Generic with PEP 696 type params**
- **refactor(domain): PEP 696 type params compliant**
- **refactor(application): modernize MessageHandler to PEP 695 inline generics; retain TypeVars for CommandHandler/QueryHandler/EventHandler TypeAlias definitions**
- **refactor(application): modernize UseCase to PEP 695 inline generics; drop module-level TypeVar declarations**
- **refactor(application): modernize MessageBus to PEP 695 inline generics; drop module-level TypeVar declarations**
- **refactor(application): modernize Notifier to PEP 695 inline generics; drop module-level TypeVar declaration**
- **refactor(application): modernize QueryFetcher to PEP 695 inline generics; drop module-level TypeVar declaration**
- **refactor(application): modernize ReadOnlyRepository/WriteOnlyRepository/Repository to PEP 695 inline generics; drop module-level TypeVar declarations**
- **refactor(infrastructure): modernize InMemoryMessageBus to PEP 695 inline generics; drop module-level TypeVar declarations**
- **refactor(infrastructure): modernize InMemoryReadRepository to PEP 695 inline generics; drop module-level TypeVar declarations**
- **refactor(infrastructure): modernize InMemoryWriteRepository to PEP 695 inline generics; drop module-level TypeVar declarations; add MutableMapping import**
