### PR TITLE
chore/adjust redirect template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: "0"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/pr-preview-docs.yml
+++ b/.github/workflows/pr-preview-docs.yml
@@ -1,0 +1,63 @@
+name: Deploy PR Preview Docs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/pr-preview-with-rossjrw.yml"
+
+concurrency: preview-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-and-deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
+      - name: Install documentation dependencies
+        if: github.event.action != 'closed'
+        run: |
+          poetry install --no-interaction --with docs
+
+      - name: Generate documentation pages
+        if: github.event.action != 'closed'
+        run: |
+          poetry run python scripts/generate_autodoc_pages.py
+
+      - name: Build documentation site
+        if: github.event.action != 'closed'
+        run: |
+          poetry run mkdocs build --strict
+
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto
+          comment: true
+          qr-code: true
+          wait-for-pages-deployment: true

--- a/.github/workflows/pr-preview-docs.yml
+++ b/.github/workflows/pr-preview-docs.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        stages: [push]
 
       - id: prevent-mkdocs-yml-change
         name: Prevent committing modified mkdocs.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        stages: [push]
+        stages: [pre-push]
 
       - id: prevent-mkdocs-yml-change
         name: Prevent committing modified mkdocs.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,4 @@ repos:
         entry: bash -c 'git diff --cached --name-only | grep -q "^mkdocs.yml$" && { echo "[ERROR] mkdocs.yml changes are not allowed to be committed!"; exit 1; } || exit 0'
         language: system
         types: [file]
+        files: ^mkdocs\.yml$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,20 @@ If a change affects public behavior, documentation updates are expected.
 3. **Install dependencies**: `poetry install`
 4. **Set up pre-commit hooks**: `pre-commit install`
 
+
+### Automation Hooks
+
+The project uses `pre-commit` to automate quality checks.
+
+- **Pre-commit (Linting):** Runs on every commit. It checks for code style, trailing whitespace, and common errors. It is designed to be fast.
+- **Pre-push (Pipeline):** Runs on every push. It executes the full pipeline (`poetry run poe ci:simulate`), including type checking, all tests, and security scanning, to ensure the remote branch remains stable.
+
+To install both:
+```bash
+pre-commit install
+pre-commit install --hook-type pre-push
+```
+
 ### Making Changes
 
 1. **Create a feature branch**: `git checkout -b feature/your-feature`

--- a/docs/redirect_template.html
+++ b/docs/redirect_template.html
@@ -143,6 +143,18 @@
           }, 3000);
         }
 
+        /*
+         * Extract the directory prefix from serverDefault so that the
+         * version-pinned redirect stays relative to the same base as the
+         * serverDefault path.
+         *
+         *   root  page: serverDefault = "dev/"        => prefix = ""
+         *   alias page: serverDefault = "../v0.4.1/"  => prefix = "../"
+         */
+        var defaultPath = serverDefault.replace(/\/$/, "");
+        var lastSlash = defaultPath.lastIndexOf("/");
+        var prefix = lastSlash >= 0 ? defaultPath.substring(0, lastSlash + 1) : "";
+
         fetch(versionsUrl)
           .then(function(r) { return r.ok ? r.json() : Promise.reject(r); })
           .then(function(versions) {
@@ -151,7 +163,7 @@
               if (versions[i].is_default) { def = versions[i]; break; }
             }
             if (!def && versions.length > 0) def = versions[0];
-            doRedirect(def ? def.version + "/" : serverDefault);
+            doRedirect(def ? prefix + def.version + "/" : serverDefault);
           })
           .catch(function() { doRedirect(serverDefault); });
       })();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,7 @@ test = { env = { "RUN_GITHUB_CLI_TESTS" = "1", "RUN_E2E_TESTS" = "1" }, cmd = "p
 
 "docs:generate" = { cmd = "python scripts/generate_autodoc_pages.py" }
 
-"docs:build" = { cmd = "python scripts/generate_autodoc_pages.py && poetry run mkdocs build --strict" }
+"docs:build" = { shell = "python scripts/generate_autodoc_pages.py && poetry run mkdocs build --strict && git checkout -- mkdocs.yml" }
 
 "docs:serve" = { shell = "python scripts/generate_autodoc_pages.py && poetry run mike serve" }
 "docs:deploy:dev" = { shell = "poetry run poe docs:generate && poetry run mike deploy --push --update-aliases dev latest && poetry run mike set-default --push dev" }

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -133,7 +133,6 @@ def extract_header(html: str) -> str:
     def replace_attr(match: re.Match[str]) -> str:
         attr_name: str = match.group(1)
         url: str = match.group(2)
-        # Special cases that should not be prefixed
         if url in (".", "#") or url.startswith("../"):
             return match.group(0)
         if _is_local_url(url):

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -78,7 +78,17 @@ def extract_head_assets(html: str) -> str:
             parts.append(m.group(1))
 
     # Generator
+    # Favicon
+    m = re.search(r'<link rel="icon" href="([^"]+)"[^>]*>', head_content)
+    if m:
+        href = m.group(1)
+        if _is_trusted_url(href):
+            parts.append(f'<link rel="icon" href="{{{{ href }}}}{href}">')
+
     m = re.search(r"(<meta name=\"generator\"[^>]*>)", head_content)
+    if m:
+        parts.append(m.group(1))
+
     # CSS stylesheets (keep all trusted ones, skip untrusted external)
     for m in re.finditer(r'<link rel="stylesheet" href="([^"]+)"', head_content):
         href = m.group(1)

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -161,7 +161,7 @@ def extract_header(html: str) -> str:
 def extract_scripts(html: str) -> str:
     """Extract JS scripts from the page."""
     scripts: list[str] = []
-    for m in re.finditer(r'<script src="([^"]+)"[^>]*>\s*</script\s*>', html):
+    for m in re.finditer(r'<script src="([^"]+)"[^>]*></script[^>]*>', html, re.IGNORECASE):
         src = m.group(1)
         if _is_trusted_url(src):
             scripts.append(f'<script src="{{{{ href }}}}{src}"></script>')

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -13,7 +13,6 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
-
 # Trusted external domains that are allowed in the redirect template
 TRUSTED_EXTERNAL_DOMAINS = {
     "fonts.googleapis.com",
@@ -88,7 +87,8 @@ def extract_head_assets(html: str) -> str:
         # Skip untrusted external stylesheets
 
     # Google Fonts and preconnect (keep only trusted external)
-    for m in re.finditer(r'<link[^>]*href="https?://fonts\.(?:googleapis|gstatic)\.com[^"]*"[^>]*>', head_content):
+    fonts_pattern = r'<link[^>]*href="https?://fonts\.(?:googleapis|gstatic)\.com[^"]*"[^>]*>'
+    for m in re.finditer(fonts_pattern, head_content):
         link_tag = m.group(0)
         # Extract href from the link tag
         href_match = re.search(r'href="([^"]+)"', link_tag)

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -119,7 +119,14 @@ def extract_body_attrs(html: str) -> str:
     """Extract body tag attributes."""
     m = re.search(r"<body([^>]*)>", html)
     if m:
-        return m.group(1).strip()
+        attrs = m.group(1).strip()
+        # Handle self-closing body tag (<body/>)
+        if attrs.endswith("/"):
+            return (
+                'dir="ltr" data-md-color-scheme="slate" '
+                'data-md-color-primary="orange" data-md-color-accent="amber"'
+            )
+        return attrs
     return (
         'dir="ltr" data-md-color-scheme="slate" '
         'data-md-color-primary="orange" data-md-color-accent="amber"'
@@ -181,6 +188,18 @@ def generate_template(source_html: str, output_path: Path) -> None:
           }}, 3000);
         }}
 
+        /*
+         * Extract the directory prefix from serverDefault so that the
+         * version-pinned redirect stays relative to the same base as the
+         * serverDefault path.
+         *
+         *   root  page: serverDefault = "dev/"        => prefix = ""
+         *   alias page: serverDefault = "../v0.4.1/"  => prefix = "../"
+         */
+        var defaultPath = serverDefault.replace(/\\/$/, "");
+        var lastSlash = defaultPath.lastIndexOf("/");
+        var prefix = lastSlash >= 0 ? defaultPath.substring(0, lastSlash + 1) : "";
+
         fetch(versionsUrl)
           .then(function(r) {{ return r.ok ? r.json() : Promise.reject(r); }})
           .then(function(versions) {{
@@ -189,7 +208,7 @@ def generate_template(source_html: str, output_path: Path) -> None:
               if (versions[i].is_default) {{ def = versions[i]; break; }}
             }}
             if (!def && versions.length > 0) def = versions[0];
-            doRedirect(def ? def.version + "/" : serverDefault);
+            doRedirect(def ? prefix + def.version + "/" : serverDefault);
           }})
           .catch(function() {{ doRedirect(serverDefault); }});
       }})();

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -161,7 +161,7 @@ def extract_header(html: str) -> str:
 def extract_scripts(html: str) -> str:
     """Extract JS scripts from the page."""
     scripts: list[str] = []
-    for m in re.finditer(r'<script src="([^"]+)"[^>]*></script>', html):
+    for m in re.finditer(r'<script src="([^"]+)"[^>]*>\s*</script\s*>', html):
         src = m.group(1)
         if _is_trusted_url(src):
             scripts.append(f'<script src="{{{{ href }}}}{src}"></script>')

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -8,11 +8,52 @@ The template uses Jinja2 `{{ href }}` placeholders that mike replaces
 at set-default time with the version path (e.g., `dev/`).
 """
 
-from __future__ import annotations
-
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
+
+
+# Trusted external domains that are allowed in the redirect template
+TRUSTED_EXTERNAL_DOMAINS = {
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+}
+
+
+def _is_local_url(url: str) -> bool:
+    """Check if a URL is a local relative path.
+
+    Args:
+        url: The URL to check
+
+    Returns:
+        True if the URL is a local relative path, False otherwise
+    """
+    if not url:
+        return False
+    return url.startswith(("/", "./", "../")) or not urlparse(url).netloc
+
+
+def _is_trusted_url(url: str) -> bool:
+    """Check if a URL is from a trusted domain or is a local relative path.
+
+    Args:
+        url: The URL to check
+
+    Returns:
+        True if the URL is trusted (local or from allowlist), False otherwise
+    """
+    if _is_local_url(url):
+        return True
+
+    # Parse the URL and check the hostname against allowlist
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        return hostname in TRUSTED_EXTERNAL_DOMAINS
+    except Exception:
+        return False
 
 
 def extract_head_assets(html: str) -> str:
@@ -39,27 +80,20 @@ def extract_head_assets(html: str) -> str:
 
     # Generator
     m = re.search(r"(<meta name=\"generator\"[^>]*>)", head_content)
-    if m:
-        parts.append(m.group(1))
-
-    # Title (we override this)
-    # Favicon
-    m = re.search(r"(<link rel=\"icon\"[^>]*>)", head_content)
-    if m:
-        parts.append('<link rel="icon" href="{{ href }}assets/favicon.ico">')
-
-    # Remove canonical and next links
-
-    # CSS stylesheets (keep all local ones, skip external)
-    for m in re.finditer(r'<link rel="stylesheet" href="(?!https?://)([^"]+)"', head_content):
+    # CSS stylesheets (keep all trusted ones, skip untrusted external)
+    for m in re.finditer(r'<link rel="stylesheet" href="([^"]+)"', head_content):
         href = m.group(1)
-        # Skip mkdocstrings CSS if it causes issues (usually fine)
-        parts.append(f'<link rel="stylesheet" href="{{{{ href }}}}{href}">')
+        if _is_trusted_url(href):
+            parts.append(f'<link rel="stylesheet" href="{{{{ href }}}}{href}">')
+        # Skip untrusted external stylesheets
 
-    # Google Fonts and preconnect (keep as-is, they're external)
-    for m in re.finditer(r"<link[^>]*fonts\.[^>]*>", head_content):
-        parts.append(m.group(0))
-
+    # Google Fonts and preconnect (keep only trusted external)
+    for m in re.finditer(r'<link[^>]*href="https?://fonts\.(?:googleapis|gstatic)\.com[^"]*"[^>]*>', head_content):
+        link_tag = m.group(0)
+        # Extract href from the link tag
+        href_match = re.search(r'href="([^"]+)"', link_tag)
+        if href_match and _is_trusted_url(href_match.group(1)):
+            parts.append(link_tag)
     # Inline style for fonts
     m = re.search(r"<style>:root\{[^}]*--md-text-font[^<]*</style>", head_content)
     if m:
@@ -90,16 +124,27 @@ def extract_header(html: str) -> str:
         flags=re.DOTALL,
     )
 
-    # Add {{ href }} prefix to local asset references
+    # Add {{ href }} prefix to local/trusted asset references
+    # Special cases that should NOT get the prefix:
+    # - "." (current page)
+    # - "#" (anchor)
+    # - "../" (parent relative)
+    # - Trusted external domains (fonts.googleapis.com, fonts.gstatic.com)
+    def replace_attr(match: re.Match[str]) -> str:
+        attr_name: str = match.group(1)
+        url: str = match.group(2)
+        # Special cases that should not be prefixed
+        if url in (".", "#") or url.startswith("../"):
+            return match.group(0)
+        if _is_local_url(url):
+            return f'{attr_name}="{{{{ href }}}}{url}"'
+        return match.group(0)
+
     header = re.sub(
-        r'(src|href)="(?!https?://|#|\.\./)([^"]+)"',
-        r'\1="{{ href }}\2"',
+        r'(src|href)="([^"]+)"',
+        replace_attr,
         header,
     )
-
-    # Fix the home link: if it's just "." keep it as "." (it stays on root)
-    # but other relative links should get the {{ href }} prefix
-    # Actually we want all local assets to point to the version directory
 
     return header
 
@@ -107,8 +152,11 @@ def extract_header(html: str) -> str:
 def extract_scripts(html: str) -> str:
     """Extract JS scripts from the page."""
     scripts: list[str] = []
-    for m in re.finditer(r'<script src="(?!https?://)(assets/[^"]+)"[^>]*></script>', html):
-        scripts.append(f'<script src="{{{{ href }}}}{m.group(1)}"></script>')
+    for m in re.finditer(r'<script src="([^"]+)"[^>]*></script>', html):
+        src = m.group(1)
+        if _is_trusted_url(src):
+            scripts.append(f'<script src="{{{{ href }}}}{src}"></script>')
+        # Skip untrusted external scripts
 
     # Skip __config inline script - it's too complex and not needed for redirect page
 

--- a/tests/scripts/test_generate_redirect_template.py
+++ b/tests/scripts/test_generate_redirect_template.py
@@ -211,6 +211,16 @@ class TestExtractScripts:
         assert "local.js" in result
         assert "cdn.example.com" not in result
 
+    def test_when_closing_tag_has_trailing_whitespace_then_still_matches(self) -> None:
+        html = """<html><head></head><body>
+<script src="assets/foo.js"></script >
+<script src="assets/bar.js"></script  >
+</body></html>"""
+        result = extract_scripts(html)
+
+        assert "foo.js" in result
+        assert "bar.js" in result
+
 
 @pytest.mark.unit
 class TestExtractBodyAttrs:

--- a/tests/scripts/test_generate_redirect_template.py
+++ b/tests/scripts/test_generate_redirect_template.py
@@ -8,9 +8,7 @@ from scripts.generate_redirect_template import (
     extract_header,
     extract_scripts,
     generate_template,
-    main,
 )
-
 
 def _build_head_html(*extras: str) -> str:
     base = """<head>

--- a/tests/scripts/test_generate_redirect_template.py
+++ b/tests/scripts/test_generate_redirect_template.py
@@ -78,7 +78,7 @@ class TestExtractHeadAssets:
         assert "{{ href }}assets/favicon.ico" in result
         assert "{{ href }}assets/stylesheets/main" in result
         assert "__md_scope" in result
-        assert "fonts.googleapis.com" in result
+        assert 'href="https://fonts.googleapis.com/css' in result
         assert "--md-text-font" in result
 
     def test_when_head_missing_then_raises_value_error(self) -> None:
@@ -220,6 +220,24 @@ class TestExtractScripts:
 
         assert "foo.js" in result
         assert "bar.js" in result
+
+    def test_when_closing_script_tag_has_extra_attributes_then_still_matches(self) -> None:
+        html = """<html><head></head><body>
+<script src="assets/attr.js"></script foo="bar">
+</body></html>"""
+        result = extract_scripts(html)
+
+        assert "attr.js" in result
+
+    def test_when_script_tags_are_uppercase_then_still_matches(self) -> None:
+        html = """<html><head></head><body>
+<SCRIPT src="assets/upper.js"></SCRIPT>
+<script src="assets/mixed.js"></SCRIPT>
+</body></html>"""
+        result = extract_scripts(html)
+
+        assert "upper.js" in result
+        assert "mixed.js" in result
 
 
 @pytest.mark.unit

--- a/tests/scripts/test_generate_redirect_template.py
+++ b/tests/scripts/test_generate_redirect_template.py
@@ -10,6 +10,7 @@ from scripts.generate_redirect_template import (
     generate_template,
 )
 
+
 def _build_head_html(*extras: str) -> str:
     base = """<head>
     <meta charset="utf-8">

--- a/tests/scripts/test_generate_redirect_template.py
+++ b/tests/scripts/test_generate_redirect_template.py
@@ -1,0 +1,357 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+from pathlib import Path
+
+import pytest
+from scripts.generate_redirect_template import (
+    extract_body_attrs,
+    extract_head_assets,
+    extract_header,
+    extract_scripts,
+    generate_template,
+    main,
+)
+
+
+def _build_head_html(*extras: str) -> str:
+    base = """<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Composable toolkit">
+    <meta name="author" content="ForgingBlocks Org">
+    <meta name="generator" content="mkdocs-1.6.1, mkdocs-material-9.6.23">
+    <link rel="icon" href="assets/favicon.ico">
+    <link rel="stylesheet" href="assets/stylesheets/main.84d31ad4.min.css">
+    <link rel="stylesheet" href="assets/stylesheets/palette.06af60db.min.css">
+    <link rel="stylesheet" href="assets/_mkdocstrings.css">
+    <link rel="stylesheet" href="assets/css/theme.css">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i%7CRoboto+Mono:400,400i,700,700i&display=fallback">
+    <style>:root{--md-text-font:"Roboto";--md-code-font:"Roboto Mono"}</style>
+    <script>__md_scope=new URL(".",location),__md_hash=e=>[...e].reduce(((e,_)=>(e<<5)-e+_.charCodeAt(0)),0),__md_get=(e,_=localStorage,t=__md_scope)=>JSON.parse(_.getItem(t.pathname+"."+e)),__md_set=(e,_,t=localStorage,a=__md_scope)=>{try{t.setItem(a.pathname+"."+e,JSON.stringify(_))}catch(e){}}</script>
+    <title>ForgingBlocks</title>
+"""
+    return base + "".join(extras) + "\n</head>"
+
+
+def _build_page_html(head: str, body_extra: str = "") -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+{head}
+<body dir="ltr" data-md-color-scheme="slate" data-md-color-primary="orange" data-md-color-accent="amber">
+<div data-md-component="announce"></div>
+<header class="md-header" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="Header">
+    <a href="." title="ForgingBlocks" class="md-header__button md-logo" aria-label="ForgingBlocks" data-md-component="logo">
+  <img src="assets/logo.png" alt="logo">
+    </a>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">ForgingBlocks</span></div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">Home</span>
+        </div>
+      </div>
+    </div>
+  </nav>
+</header>
+{body_extra}
+<script src="assets/javascripts/bundle.f55a23d4.min.js"></script>
+<script src="assets/js/version-dropdown.js"></script>
+<script src="assets/js/mermaid-init.js"></script>
+<script>var __config=JSON.parse('{{"key":"value"}}')</script>
+</body>
+"""
+
+
+@pytest.mark.unit
+class TestExtractHeadAssets:
+    def test_when_valid_head_then_includes_meta_and_css(self) -> None:
+        head = _build_head_html()
+        html = _build_page_html(head)
+        result = extract_head_assets(html)
+
+        assert "charset" in result
+        assert "viewport" in result
+        assert "Composable toolkit" in result
+        assert "ForgingBlocks Org" in result
+        assert "generator" in result
+        assert "{{ href }}assets/favicon.ico" in result
+        assert "{{ href }}assets/stylesheets/main" in result
+        assert "__md_scope" in result
+        assert "fonts.googleapis.com" in result
+        assert "--md-text-font" in result
+
+    def test_when_head_missing_then_raises_value_error(self) -> None:
+        html = "<html><body>no head</body></html>"
+        with pytest.raises(ValueError, match="No <head>"):
+            extract_head_assets(html)
+
+    def test_when_head_has_no_meta_tags_then_returns_only_matched(self) -> None:
+        head = """<head>
+    <title>Empty</title>
+    <link rel="stylesheet" href="assets/theme.css">
+    </head>"""
+        html = _build_page_html(head)
+        result = extract_head_assets(html)
+
+        assert "charset" not in result
+        assert "viewport" not in result
+        assert "{{ href }}assets/theme.css" in result
+
+    def test_when_external_stylesheets_are_skipped(self) -> None:
+        head = """<head>
+    <link rel="stylesheet" href="assets/local.css">
+    <link rel="stylesheet" href="https://cdn.example.com/external.css">
+    </head>"""
+        html = _build_page_html(head)
+        result = extract_head_assets(html)
+
+        assert "{{ href }}assets/local.css" in result
+        assert "cdn.example.com" not in result
+
+    def test_when_no_favicon_in_source_then_no_favicon_link(self) -> None:
+        head = "<head></head>"
+        html = _build_page_html(head)
+        result = extract_head_assets(html)
+
+        # No favicon in source, so no favicon in result (implementation doesn't add default)
+        assert "{{ href }}assets/favicon.ico" not in result
+        assert result == ""
+
+
+@pytest.mark.unit
+class TestExtractHeader:
+    def test_when_valid_header_then_returns_header_with_template_hrefs(self) -> None:
+        html = _build_page_html(_build_head_html())
+        result = extract_header(html)
+
+        assert '<header class="md-header"' in result
+        assert "ForgingBlocks" in result
+        assert "Redirecting..." in result
+        assert "{{ href }}assets/logo.png" in result
+
+    def test_when_header_missing_then_raises_value_error(self) -> None:
+        html = "<html><head></head><body>no header</body></html>"
+        with pytest.raises(ValueError, match="No <header>"):
+            extract_header(html)
+
+    def test_when_header_topic_is_home_then_replaces_with_redirecting(self) -> None:
+        html = _build_page_html(_build_head_html())
+        result = extract_header(html)
+
+        assert "Home" not in result or result.count("Home") == 0
+        assert "Redirecting..." in result
+
+    def test_when_header_topic_is_forging_blocks_then_replaces(self) -> None:
+        head = _build_head_html()
+        html = _build_page_html(head).replace(
+            '<span class="md-ellipsis">Home</span>',
+            '<span class="md-ellipsis">ForgingBlocks</span>',
+        )
+        result = extract_header(html)
+
+        assert "Redirecting..." in result
+        assert "ForgingBlocks" in result
+
+    def test_when_local_src_in_header_then_adds_template_prefix(self) -> None:
+        head = _build_head_html()
+        html = _build_page_html(head).replace(
+            '<img src="assets/logo.png"',
+            '<img src="assets/logo.png" data-src="assets/logo-dark.png"',
+        )
+        result = extract_header(html)
+
+        assert "{{ href }}assets/logo.png" in result
+        assert "{{ href }}assets/logo-dark.png" in result
+
+    def test_when_external_href_in_header_then_does_not_add_prefix(self) -> None:
+        head = _build_head_html()
+        html = _build_page_html(head).replace(
+            '<img src="assets/logo.png"',
+            '<img src="https://example.com/logo.png"',
+        )
+        result = extract_header(html)
+
+        assert 'src="{{ href }}https' not in result
+        assert 'src="https://example.com/logo.png"' in result
+
+    def test_when_hash_href_in_header_then_does_not_add_prefix(self) -> None:
+        pass
+
+
+@pytest.mark.unit
+class TestExtractScripts:
+    def test_when_scripts_are_present_then_returns_template_prefixed(self) -> None:
+        html = _build_page_html(_build_head_html())
+        result = extract_scripts(html)
+
+        assert "{{ href }}assets/javascripts/bundle" in result
+        assert "{{ href }}assets/js/version-dropdown.js" in result
+        assert "{{ href }}assets/js/mermaid-init.js" in result
+
+    def test_when_inline_script_is_skipped(self) -> None:
+        html = _build_page_html(_build_head_html())
+        result = extract_scripts(html)
+
+        assert "__config" not in result
+
+    def test_when_no_scripts_then_returns_empty(self) -> None:
+        html = "<html><head></head><body></body></html>"
+        result = extract_scripts(html)
+
+        assert result == ""
+
+    def test_when_external_script_then_skipped(self) -> None:
+        html = """<html><head></head><body>
+<script src="assets/local.js"></script>
+<script src="https://cdn.example.com/remote.js"></script>
+</body></html>"""
+        result = extract_scripts(html)
+
+        assert "local.js" in result
+        assert "cdn.example.com" not in result
+
+
+@pytest.mark.unit
+class TestExtractBodyAttrs:
+    def test_when_body_attrs_present_then_returns_them(self) -> None:
+        html = _build_page_html(_build_head_html())
+        result = extract_body_attrs(html)
+
+        assert 'dir="ltr"' in result
+        assert 'data-md-color-scheme="slate"' in result
+        assert 'data-md-color-primary="orange"' in result
+
+    def test_when_body_has_no_attrs_then_returns_defaults(self) -> None:
+        html = "<html><head></head><body></body></html>"
+        result = extract_body_attrs(html)
+
+        # Body tag exists but has no attributes, so empty string is returned
+        assert result == ""
+
+
+@pytest.mark.unit
+class TestGenerateTemplate:
+    def test_when_valid_html_then_writes_template_file(self, tmp_path: Path) -> None:
+        html = _build_page_html(_build_head_html())
+        output = tmp_path / "redirect_template.html"
+
+        generate_template(html, output)
+
+        assert output.exists()
+        content = output.read_text(encoding="utf-8")
+        assert "<!DOCTYPE html>" in content
+        assert "ForgingBlocks - Redirecting" in content
+        assert "{{ href }}" in content
+        assert "redirect-link" in content
+        assert "Documentation Redirect" in content
+
+    def test_when_template_contains_fixed_redirect_logic(self, tmp_path: Path) -> None:
+        html = _build_page_html(_build_head_html())
+        output = tmp_path / "redirect_template.html"
+
+        generate_template(html, output)
+
+        content = output.read_text(encoding="utf-8")
+        assert "prefix + def.version + " in content
+        assert 'var defaultPath = serverDefault.replace(/\\/$/, "")' in content
+        assert "lastIndexOf" in content
+        assert 'doRedirect(def ? prefix + def.version + "/" : serverDefault)' in content
+
+    def test_when_template_has_all_placeholders(self, tmp_path: Path) -> None:
+        html = _build_page_html(_build_head_html())
+        output = tmp_path / "redirect_template.html"
+
+        generate_template(html, output)
+
+        content = output.read_text(encoding="utf-8")
+        assert content.count("{{ href }}") >= 5
+
+    def test_when_template_has_version_dropdown_scripts(self, tmp_path: Path) -> None:
+        html = _build_page_html(_build_head_html())
+        output = tmp_path / "redirect_template.html"
+
+        generate_template(html, output)
+
+        content = output.read_text(encoding="utf-8")
+        assert "version-dropdown.js" in content
+        assert "mermaid-init.js" in content
+
+    def test_when_template_has_redirect_js_function(self, tmp_path: Path) -> None:
+        html = _build_page_html(_build_head_html())
+        output = tmp_path / "redirect_template.html"
+
+        generate_template(html, output)
+
+        content = output.read_text(encoding="utf-8")
+        assert "function doRedirect(target)" in content
+        assert "window.location.replace" in content
+        assert "setTimeout" in content
+
+    def test_when_minimal_html_then_still_generates_valid(self, tmp_path: Path) -> None:
+        html = """<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body dir="ltr" data-md-color-scheme="slate" data-md-color-primary="orange" data-md-color-accent="amber">
+<div data-md-component="announce"></div>
+<header class="md-header" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="Header">
+    <a href="." title="ForgingBlocks" class="md-header__button md-logo">
+  <img src="assets/logo.png" alt="logo">
+    </a>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">ForgingBlocks</span></div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">Home</span>
+        </div>
+      </div>
+    </div>
+  </nav>
+</header>
+</body>
+</html>"""
+        output = tmp_path / "redirect_template.html"
+
+        generate_template(html, output)
+
+        content = output.read_text(encoding="utf-8")
+        assert "<!DOCTYPE html>" in content
+        assert "ForgingBlocks - Redirecting" in content
+        assert "Redirecting..." in content
+
+    def test_when_body_self_closing_then_uses_default_attrs(self) -> None:
+        html = """<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body/>
+</html>"""
+        result = extract_body_attrs(html)
+
+        # Self-closing body tag has no attributes, so defaults are returned
+        assert 'dir="ltr"' in result
+        assert "slate" in result
+
+    def test_when_body_has_extra_attrs_then_preserves_them(self) -> None:
+        html = '<html><head></head><body class="extra" id="main"></body></html>'
+        result = extract_body_attrs(html)
+
+        assert 'class="extra"' in result
+        assert 'id="main"' in result
+
+        head = _build_head_html()
+        html = _build_page_html(head).replace('href="."', 'href="#"')
+        result = extract_header(html)
+
+        assert 'href="{{ href }}#' not in result
+        assert 'href="#"' in result
+
+    def test_when_parent_relative_href_then_does_not_add_prefix(self) -> None:
+        head = _build_head_html()
+        html = _build_page_html(head).replace('href="."', 'href="../something"')
+        result = extract_header(html)
+
+        assert 'href="{{ href }}..' not in result
+        assert 'href="../something"' in result


### PR DESCRIPTION
- **chore(scripts): redirect template adjusts**
- **chore(scripts): redirect template adjusts**
- **chore(workflows): pr preview docs**
- **fix(scripts): correct redirect template asset prefixing and type hints**
- **chore(tests): remove unused import in redirect template tests**
- **chore(git): move CI simulation to pre-push hook stage**
- **docs(contributing): document pre-commit and pre-push hooks**
- **fix(scripts): resolve ruff line length error in redirect template script**
- **chore(tests): cleanup redirect template tests**
- **style: remove useless comment**
- **fix(scripts): ensure favicon is extracted and prefixed in redirect template**
- **chore: pre-push**
- **chore(git): restrict mkdocs.yml check to only run when the file is changed**
- **fix(build): restore mkdocs.yml after docs:build to keep working tree clean for pre-commit**
- **chore(scripts): adjust regex**
- **fix: make script tag regex handle edge cases in closing tags**
- **test: cover script tag regex edge cases and fix CodeQL warning**
- **chore(workflows): update setup-python action**
