### PR TITLE
docs/clean docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,22 @@
 # Contributing to ForgingBlocks
 
+Hey there :)
+
 Thank you for your interest in contributing to ForgingBlocks.
 
 This document explains **how to participate** in the project and where to find the rules that apply once you start contributing.
 
 You do not need to read everything before opening a pull request.
 This guide is meant to help you orient yourself.
+
+---
+## Quick summary
+
+- This file explains **how to contribute**.
+- Other documents explain **how things should be written or structured**.
+- When in doubt, ask questions early.
+
+Contributions are welcome as long as they respect the project's emphasis on clarity, boundaries, and intentional design.
 
 ---
 
@@ -40,6 +51,8 @@ Understanding this separation will make contributing easier.
 ## Documentation contributions
 
 Documentation is a first-class concern in this project.
+
+You have to write expressive docstrings because docstrings generates autodocs.
 
 If you plan to modify or add documentation, please read:
 
@@ -88,7 +101,7 @@ pre-commit install --hook-type pre-push
 
 ### Making Changes
 
-1. **Create a feature branch**: `git checkout -b feature/your-feature`
+1. **Create a feature branch**: `git checkout -b feat/your-feature`
 2. **Make your changes**
 3. **Add tests** for new functionality (see [Testing Guidelines](#testing-guidelines))
 4. **Run the full test suite**:
@@ -153,6 +166,7 @@ poetry run poe docs:generate        # Generate API reference
 poetry run poe docs:deploy-version  # Deploy versioned docs (see --help)
 poetry run poe docs:serve-versioned # Serve with version selector
 poetry run poe docs:list-versions   # List deployed versions
+```
 
 ### Release Process (Maintainers Only)
 
@@ -165,13 +179,3 @@ poetry run poe release patch
 # Execute release (creates branch and PR)
 poetry run poe release patch --execute
 ```
-
----
-
-## In short
-
-- This file explains **how to contribute**.
-- Other documents explain **how things should be written or structured**.
-- When in doubt, ask questions early.
-
-Contributions are welcome as long as they respect the project’s emphasis on clarity, boundaries, and intentional design.

--- a/docs/architectural-styles/clean-architecture.md
+++ b/docs/architectural-styles/clean-architecture.md
@@ -8,6 +8,22 @@ This page shows how **ForgingBlocks concepts can be projected** onto a Clean Arc
     ForgingBlocks does **not** enforce Clean Architecture.
     This page presents it as an **interpretation**, not a required structure.
 
+---
+
+## Quick summary
+
+Clean Architecture organizes software around **behavioral boundaries** and dependency rules that protect core policies from external details. This page shows how **ForgingBlocks concepts can be projected** onto this arrangement — **not enforced**.
+
+Mapping:
+- **Inner layers** — Domain (Entities, Value Objects) + Application (Use Cases, Handlers)
+- **Outer layers** — Delivery mechanisms, technical details (Frameworks, Drivers, Interface Adapters)
+- **Dependencies always point inward**
+
+Fits when: long-term maintainability matters; strict policy/detail separation needed; multiple delivery mechanisms expected.
+Consider alternatives when: simplicity > flexibility; strict rules add overhead; system is small/short-lived.
+
+---
+
 ## Conceptual mapping
 
 - The inner layers contain Domain and Application policies.
@@ -26,12 +42,15 @@ graph TD
     Application -->|coordinate| Domain[Enterprise Business Rules<br/>Entities, Value Objects]
 ```
 
+---
 
 ## When this style fits
 
 - Long-term maintainability is a priority.
 - Strict separation between policy and details is required.
 - Multiple delivery mechanisms are expected.
+
+---
 
 ## When to consider alternatives
 

--- a/docs/architectural-styles/cqrs.md
+++ b/docs/architectural-styles/cqrs.md
@@ -8,6 +8,21 @@ This page shows how **ForgingBlocks concepts can be projected** to support a CQR
     ForgingBlocks does **not** require CQRS.
     This page presents it as an **architectural pattern**, not a requirement.
 
+---
+
+## Quick summary
+
+Command Query Responsibility Segregation (CQRS) separates **write behavior** from **read behavior**. This page shows how **ForgingBlocks concepts can be projected** to support CQRS — **not required**.
+
+Mapping:
+- **Commands** — Express intent to change state (`Command`, `CommandHandler`, `WriteOnlyRepository`)
+- **Queries** — Retrieve information (`Query`, `QueryHandler`, `ReadOnlyRepository`)
+- **Models may diverge** over time (separate read/write stores with replication)
+
+Fits when: read/write workloads differ significantly; scalability dominates; eventual consistency acceptable.
+
+---
+
 ## Conceptual mapping
 
 - Commands express intent to change state.
@@ -29,6 +44,7 @@ graph LR
     WriteStore -.->|replicate| ReadStore
 ```
 
+---
 
 ## When this style fits
 

--- a/docs/architectural-styles/event-driven.md
+++ b/docs/architectural-styles/event-driven.md
@@ -8,6 +8,22 @@ This page shows how **ForgingBlocks abstractions can participate** in an event-d
     ForgingBlocks does **not** require an event-driven architecture.
     This page presents it as a **pattern**, not a mandate.
 
+---
+
+## Quick summary
+
+Event-Driven Architecture focuses on **reacting to events** and **propagating facts** across system boundaries. This page shows how **ForgingBlocks abstractions can participate** in this design — **not required**.
+
+Mapping:
+- **Domain Events** — Facts that occurred (`Event`, past tense, immutable)
+- **Event Handlers** — React to events (`EventHandler`, `MessageHandler[EventType, None]`)
+- **Message Bus** — Routes events between components (`MessageBus` outbound port)
+- **Loose coupling** — Components don't call each other directly
+
+Fits when: loose coupling required; asynchronous processing desirable; frequent external system integration.
+
+---
+
 ## Conceptual mapping
 
 - Domain events represent facts that occurred.
@@ -27,6 +43,7 @@ graph LR
     EventBus -->|dispatch| ConsumerB[Consumer B<br/>Event Handler]
 ```
 
+---
 
 ## When this style fits
 

--- a/docs/architectural-styles/hexagonal-architecture.md
+++ b/docs/architectural-styles/hexagonal-architecture.md
@@ -8,6 +8,23 @@ This page shows how **ForgingBlocks concepts can be projected** onto a hexagonal
     ForgingBlocks does **not** enforce Hexagonal Architecture.
     This page presents it as an **interpretation** of responsibilities defined in the Reference section.
 
+---
+
+## Quick summary
+
+Hexagonal Architecture (Ports and Adapters) emphasizes separation between core behavior and external systems. This page shows how **ForgingBlocks concepts can be projected** onto this arrangement — **not enforced**.
+
+Mapping:
+- **Core** — Domain (business rules) + Application (Use Cases, Handlers)
+- **Inbound Ports** — Define how behavior is triggered (UseCase, MessageHandler)
+- **Outbound Ports** — Define required external capabilities (Repository, MessageBus, UnitOfWork)
+- **Adapters** — Implement ports (Infrastructure: SQL repos, message brokers, HTTP clients)
+- **Dependencies point toward the core**
+
+Fits when: external systems change frequently; testing without infrastructure matters; inbound/outbound isolation needed.
+
+---
+
 ## Conceptual mapping
 
 - The core contains Domain and Application logic.
@@ -27,6 +44,7 @@ graph LR
     ApplicationCore -->|dispatch/persist/notify| OutboundAdapters[Outbound Adapters<br/>Repositories, Message Bus]
 ```
 
+---
 
 ## When this style fits
 

--- a/docs/architectural-styles/index.md
+++ b/docs/architectural-styles/index.md
@@ -7,8 +7,19 @@ This section explores **well-known architectural styles** as they appear in the 
 These pages are not a source of definitions.
 They are intended to help you **relate ForgingBlocks concepts** to architectural styles you may already know.
 
-You can read any page in isolation.
-You can also ignore this section entirely.
+---
+
+## Quick summary
+
+This section explores **well-known architectural styles** (Clean Architecture, Hexagonal, Layered, CQRS, Event-Driven) as they appear in software architecture literature. It helps you **relate ForgingBlocks concepts** to styles you may already know.
+
+Key points:
+- Pages are **explanatory, not prescriptive** — no definitions, no imposed architecture, no recommendations
+- Each page describes one style, uses neutral terminology, shows how ForgingBlocks concepts *project* onto it
+- **Reference** section remains the source of truth for responsibilities/boundaries
+- You can read any page in isolation or skip this section entirely
+
+Useful if: you know a style and want to map it to ForgingBlocks, want to compare styles, or are exploring trade-offs.
 
 ---
 

--- a/docs/architectural-styles/layered-architecture.md
+++ b/docs/architectural-styles/layered-architecture.md
@@ -5,10 +5,24 @@ Layered Architecture organizes software into horizontal layers, each with a dist
 This page shows how **ForgingBlocks concepts can be projected** onto a traditional layered arrangement.
 
 !!! note "Important"
-    ForgingBlocks does **not** require a layered architecture.
-    This page presents Layered Architecture as an **interpretation** of responsibilities defined in the Reference section.
 
-## Conceptual mapping
+---
+
+## Quick summary
+
+Layered Architecture organizes software into horizontal layers with distinct responsibilities. This page shows how **ForgingBlocks concepts can be projected** onto this arrangement — **not required**.
+
+Mapping:
+- **Presentation** — Input/output (Controllers, CLI)
+- **Application** — Coordinates behavior (Use Cases)
+- **Domain** — Problem-space concepts (Entities, Aggregates)
+- **Infrastructure** — Technical implementations (Repositories, Message Bus)
+- **Dependencies flow downward**
+
+Fits when: system is relatively small; architectural complexity not required; simplicity/familiarity prioritized.
+Consider alternatives when: strict dependency control needed; inbound/outbound isolation required; message-driven/async workflows central.
+
+---
 
 - Presentation handles input and output concerns.
 - Application coordinates behavior.
@@ -28,12 +42,15 @@ graph TD
     Application -->|persist via| Infrastructure[Infrastructure<br/>Repositories, Message Bus]
 ```
 
+---
 
 ## When this style fits
 
 - The system is relatively small.
 - Architectural complexity is not required.
 - Simplicity and familiarity are prioritized.
+
+---
 
 ## When to consider alternatives
 

--- a/docs/contributing/docs-conventions.md
+++ b/docs/contributing/docs-conventions.md
@@ -5,11 +5,21 @@
 This document is for contributors who are **writing or modifying documentation** in the ForgingBlocks repository.
 
 It defines the conventions used across the documentation.
-These rules are intentional and should be followed consistently.
+---
+## Quick summary
+
+This document defines **conventions for writing and modifying documentation** in ForgingBlocks. These rules are intentional and ensure consistency across all documentation.
+
+Key principles:
+- Explicit behavior over implied behavior
+- Clear responsibility boundaries
+- Neutral, non-prescriptive language
+- Consistency across sections and pages
+- Explain *why* before *how*
+
+The goal is to help readers reason, not to persuade them.
 
 ---
-
-## General principles
 
 Documentation favors:
 
@@ -80,11 +90,3 @@ When modifying documentation:
 If a change requires explanation, add context explicitly.
 
 ---
-
-## In short
-
-- These conventions are deliberate.
-- Consistency is more important than creativity.
-- When in doubt, match existing documentation.
-
-This document acts as a shared contract between contributors.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -2,8 +2,13 @@
 
 Welcome! Thank you for your interest in contributing to ForgingBlocks.
 
-## Quick Start
+---
 
+## Quick summary
+
+This page serves as the **entry point for contributors** to ForgingBlocks. It provides a quick start guide and links to detailed contributing guides.
+
+Quick start:
 ```bash
 # 1. Fork and clone the repository
 git clone https://github.com/forging-blocks-org/forging-blocks.git
@@ -16,31 +21,49 @@ poetry install
 poetry run poe test
 ```
 
+Guides:
+- [Contribution Guide](contributing.md) — Setup, workflow, PR guidelines, dev commands
+- [Documentation Conventions](docs-conventions.md) — Writing style, structure rules, consistency
+- [Release Guide](release-guide.md) — For maintainers: releases, PyPI, docs deployment
+
+---
+
 ## Contributing Guides
 
 ### [Contribution Guide](contributing.md)
+
 **Start here for complete setup and workflow**
 - Development environment setup
 - Code contribution process
 - Pull request guidelines
 - Available development commands
+
 ### [Documentation Conventions](docs-conventions.md)
+
 **For documentation contributors**
 - Writing style and tone guidelines
 - Documentation structure rules
 - Consistency requirements
+
 ### [Release Guide](release-guide.md)
+
 **For maintainers**
 - How to prepare releases using poe tasks
 - Automated PR-based release workflow
 - Publishing to PyPI and docs deployment
+
+---
+
 ## Contributing Philosophy
 
 ForgingBlocks values:
-- **Quality over quantity** - Well-thought-out, focused contributions
-- **Clarity over cleverness** - Code and documentation should be easy to understand
-- **Explicit over implicit** - Make intentions and behaviors clear
-- **Consistency over convenience** - Follow established patterns
+
+- **Quality over quantity** — Well-thought-out, focused contributions
+- **Clarity over cleverness** — Code and documentation should be easy to understand
+- **Explicit over implicit** — Make intentions and behaviors clear
+- **Consistency over convenience** — Follow established patterns
+
+---
 
 ## Need Help?
 

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -2,11 +2,21 @@
 
 This document provides a clear, layered explanation of how applications built with ForgingBlocks are typically structured.
 It replaces the previous all-in-one diagram with **three focused diagrams**, each capturing a single conceptual dimension.
+---
+## Quick summary
+
+This document provides a **clear, layered explanation** of how ForgingBlocks applications are typically structured, using **three focused diagrams** (each capturing one conceptual dimension) instead of one overwhelming diagram.
+
+Diagrams:
+1. **High-Level Architectural Layers** — Request flow: Presentation → Application → Domain; Infrastructure implements outbound ports
+2. **Domain Composition** — Internal domain structure: Aggregates enforce invariants; Entities hold identity/state; Value Objects are immutable; Events capture changes
+3. **Ports & Adapters (Hexagonal View)** — How Application communicates outward: Presentation calls inbound ports; Application owns/defines ports; Infrastructure implements outbound ports; dependencies point inward
+
+Key principle: **Presentation never calls Infrastructure directly**. Application defines ports; Infrastructure implements them.
+
+Includes a minimal TL;DR diagram for quick reference.
 
 ---
-
-# 1. High-Level Architectural Layers
-
 A macro overview showing how requests flow through the system.
 
 ```mermaid

--- a/docs/guide/example_tests.md
+++ b/docs/guide/example_tests.md
@@ -4,11 +4,18 @@
 This page shows larger, more realistic examples that build on the
 concepts introduced in the [Testing](testing.md) guide.
 
-The focus here is on **observable behavior**, not on testing the toolkit itself.
+---
+## Quick summary
+
+This page shows **larger, realistic test examples** building on concepts from the [Testing](testing.md) guide. The focus is on **observable behavior** — testing your code, not the toolkit.
+
+Examples:
+1. **Composing behavior with Result** — Chaining `Result`-returning functions, testing success/error paths with pattern matching
+2. **Testing a simple use case** — Using a fake repository to test application-layer behavior without real infrastructure
+
+Key takeaway: Tests should describe **what happened**, not how the toolkit represents it. Use pattern matching when you need data; otherwise assert success/failure and move on.
 
 ---
-
-## 1. Composing behavior with Result
 
 ```python
 from forging_blocks.foundation import Result, Ok, Err

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -3,11 +3,21 @@
 
 This page collects small, focused examples that show how to use ForgingBlocks concepts in isolation.
 
-Each example is **self-contained** and does not assume any particular project structure.
+---
+## Quick summary
+
+This page collects **small, focused, architecture-neutral examples** showing how to use ForgingBlocks concepts in isolation. Each example is self-contained and assumes no particular project structure.
+
+Examples included:
+1. **Validation with Result** — Input parsing with explicit success/failure
+2. **Simple domain-like type** — Building types that don't rely on infrastructure
+3. **Using a port and adapter** — Defining boundaries with Port and implementing adapters
+4. **Modeling a value with ValueObject** — Immutable, value-based equality types
+5. **Composing errors with structured types** — Structured error modeling
+
+These are usage snippets, not templates — adapt them to your context.
 
 ---
-
-## 1. Validation with Result
 
 ```python
 from dataclasses import dataclass

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,11 +2,19 @@
 
 This guide walks through a small, complete example to help you get started with ForgingBlocks.
 
-The focus is on **explicit outcomes** and **clear boundaries**, not on frameworks or infrastructure.
+---
+## Quick summary
+
+This guide walks through a **small, complete example** to help you get started with ForgingBlocks. The focus is on **explicit outcomes** and **clear boundaries** — not frameworks or infrastructure.
+
+What you'll learn:
+- **Result** — Parse input with explicit success/failure handling (`Ok`/`Err`)
+- **ValueObject** — Wrap primitives to make domain rules visible and reusable
+- **get_value_or_else** — Handle failures without manual unpacking
+
+No framework setup required — just pure Python with ForgingBlocks abstractions.
 
 ---
-
-## Parsing input with Result
 
 ```python
 from forging_blocks.foundation import Result, Ok, Err

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,11 +6,21 @@ This documentation is organized to help you build a **clear mental model** of Fo
 
 You do not need to read everything, and you do not need to follow a strict order.
 Each section is designed to stand on its own.
+---
+## Quick summary
 
-You can use **all** of them or only some of them.
+The **Guide** section helps you build a mental model of ForgingBlocks. You don't need to read everything or follow a strict order — each section stands on its own.
+
+Key points:
+- Organized around **responsibility boundaries**, not a single architecture
+- Pages explain **what building blocks are**, **how they compose**, and **how architectural styles relate**
+- **Reference** section = precise definitions (source of truth)
+- **Architectural Styles** = optional interpretations, not requirements
+- Suggested learning paths provided, but you can move freely
+
+The goal: help you make **intentional design decisions**, not prescribe an architecture.
 
 ---
-
 ## A mental model first
 
 ForgingBlocks is built around a small set of **responsibility boundaries**.
@@ -99,13 +109,3 @@ You do **not** need to adopt any architectural style to use ForgingBlocks succes
 They are provided as learning aids, not as requirements.
 
 ---
-
-## In short
-
-- Start where it feels useful.
-- Treat examples as guidance, not templates.
-- Use the Reference when you need clarity.
-- Explore Architectural Styles only if they help your understanding.
-
-The goal of this documentation is not to tell you *what architecture to use*,
-but to help you make **intentional design decisions**.

--- a/docs/guide/principles.md
+++ b/docs/guide/principles.md
@@ -3,11 +3,21 @@
 
 ForgingBlocks is designed around a set of practical principles that help teams write code that is easy to **understand**, **change**, and **test** over time.
 
-These principles are **architecture-neutral**.
+---
+## Quick summary
 
-You can apply them whether your project is:
+ForgingBlocks is designed around **practical, architecture-neutral principles** that help teams write code that's easy to understand, change, and test over time — regardless of project size or style.
 
-- Small
+The 7 principles:
+1. **Clarity over cleverness** — Readable code wins; names express intent
+2. **Boundaries as first-class concepts** — Clear boundaries keep systems understandable (Ports, blocks, explicit contracts)
+3. **Explicit outcomes** — Model success/failure with `Result`; avoid surprise exceptions
+4. **Decoupling from tools** — Core behavior independent of databases, frameworks, queues
+5. **Small, composable abstractions** — Small protocols over deep hierarchies; adopt individually
+6. **Teachable by design** — Concepts separated and named; junior engineers can understand
+7. **Respecting existing ideas, without enforcing them** — Acknowledges DDD/Hexagonal/Clean Architecture but doesn't enforce them
+
+---
 - Large
 - Monolithic
 - Distributed

--- a/docs/guide/recommended_blocks_structure.md
+++ b/docs/guide/recommended_blocks_structure.md
@@ -4,11 +4,23 @@
 This section explains a **practical way** to organize code using blocks.
 It is a recommendation, not a rule: you can use all of these blocks, some of them, or even create your own.
 
-A **block** is simply a group of code that shares a responsibility and a boundary.
+---
+## Quick summary
+
+This section explains a **practical way to organize code using blocks** (groups of code sharing a responsibility and boundary). It's a recommendation, not a rule — use all, some, or create your own.
+
+Common blocks and their responsibilities:
+- **Foundation** — Reusable low-level abstractions (`Result`, `Port`, `Mapper`, `ValueObject`, `Messages`, errors, meta utilities). No dependencies.
+- **Domain** — Problem space concepts (Entities, Value Objects, Aggregates, Domain Errors). Depends only on Foundation.
+- **Application** — Orchestrates workflows (Use Cases, Message Handlers, Inbound/Outbound Ports). Depends on Domain + Foundation.
+- **Infrastructure** — External tech integrations (repositories, message brokers, API clients). Implements Application's outbound ports.
+- **Presentation** — Entry points (HTTP, CLI, message listeners). Calls Application; stays thin.
+
+Dependency rules (inward-pointing): Foundation → Domain → Application; Infrastructure/Presentation depend on Application; all depend on Foundation.
+
+**Block ≠ Layer** — Blocks are architecture-neutral named boundaries; interpret as layers if helpful.
 
 ---
-
-## Overview of the blocks
 
 The common blocks are:
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -5,11 +5,25 @@
 ForgingBlocks encourages designs where behavior and outcomes are explicit.
 This makes your code easier to test without relying on internal details.
 
-This guide covers both **testing principles** and the **test structure** used in this project.
+---
+## Quick summary
+
+This guide covers **testing principles** and the **3-tier test structure** used in ForgingBlocks. ForgingBlocks designs make behavior explicit, making code easier to test without relying on internal details.
+
+Test tiers:
+- **Unit** (`@pytest.mark.unit`) — Fast, isolated tests for pure business logic (Domain, Value Objects, Aggregates). Mocks/fakes OK for owned contracts.
+- **Integration** (`@pytest.mark.integration`) — Real/simulated external dependencies (repositories, message buses, APIs). Use fixtures/fakes, **not mocks**.
+- **E2E** (`@pytest.mark.e2e`) — Complete workflows from entry points (CLI, HTTP). Conditionally skipped; document full system behavior.
+
+Key principles:
+- **Test intent first** — Focus on behavior, not `Result` representation
+- **Use fakes for Ports** — Replace Port dependencies with fakes to verify behavior without infrastructure
+- **Don't mock what you don't own** — Wrap external systems behind Ports, use fakes in tests
+- **Pattern matching supports, doesn't dominate** — Use when returned value matters to intent
+
+Commands: `poe test:unit` (fast), `poe test` (all), `poe test:e2e` (conditional).
 
 ---
-
-## Test Structure & Categories
 
 This project uses a **3-tier testing architecture** with clear separation of concerns:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,20 @@ ForgingBlocks relies only on standard features available in **Python 3.14+** (su
 
 ---
 
+## Quick summary
+
+ForgingBlocks provides **foundational contracts** for designing software with clarity, intent, and expressiveness.
+
+It is **not a framework** — it gives you a vocabulary and building blocks to shape your own architecture using standard Python 3.14+ features (Protocols, Generics, Type Hints).
+
+Key points:
+- Small, composable abstractions (Result, Port, Entity, ValueObject, UseCase, etc.)
+- Architecture-neutral — works with your preferred style
+- Focus on explicit outcomes, clear boundaries, and testability
+- Zero dependencies, lightweight
+
+---
+
 ## Getting Started
 
 Install using Poetry, pip or uv:

--- a/docs/reference/application.md
+++ b/docs/reference/application.md
@@ -6,11 +6,27 @@ The **Application** block defines **what the system does**.
 It expresses system behavior by coordinating domain concepts, handling incoming requests, and invoking outbound capabilities.
 It does **not** contain business rules themselves, nor technical details.
 
-The Application block sits between the outside world and the Domain, acting as a **behavioral boundary**.
-
 ---
 
-## Purpose of the Application block
+## Quick summary
+
+The **Application** block defines **what the system does** — it coordinates domain concepts, handles incoming requests, and invokes outbound capabilities. It sits between the outside world and the Domain as a **behavioral boundary**.
+
+Core abstractions:
+- **Inbound Ports** — How the system can be interacted with
+  - **Use Case** — Cohesive unit of application behavior (orchestrates domain + outbound)
+  - **Message Handler** — Reacts to a single message (Command, Event, Query)
+- **Outbound Ports** — Capabilities the application depends on
+  - **Repository** — Persistence abstraction (ReadOnly, WriteOnly, ReadWrite)
+  - **Unit of Work** — Transactional boundary
+  - **Message Bus** — Dispatches messages
+  - **Command Sender** — Fire-and-forget commands
+  - **Event Publisher** — Publishes domain events
+  - **Query Fetcher** — Retrieves data asynchronously
+
+Depends on **Domain** and **Foundation**; must not depend on Presentation or Infrastructure implementations.
+
+---
 
 The Application block exists to:
 

--- a/docs/reference/clean-architecture.md
+++ b/docs/reference/clean-architecture.md
@@ -1,14 +1,19 @@
+# Clean Architecture Reference
+
+---
+
+## Quick summary
+
+This page provides a **visual reference** for Clean Architecture layering as it relates to ForgingBlocks concepts.
+
+The diagram shows the four concentric layers:
+- **Enterprise Business Rules** (innermost) — Domain (Entities, Value Objects)
+- **Application Business Rules** — Application (Use Cases, Handlers)
+- **Interface Adapters** — Presentation, Gateways, Controllers
+- **Frameworks & Drivers** (outermost) — Infrastructure (DB, Web, External APIs)
+
+Dependencies point inward toward the core.
+
+---
+
 ```mermaid
----
-title: Clean Architecture
----
-graph TD
-    subgraph outer["Frameworks & Drivers"]
-        subgraph adapters["Interface Adapters"]
-            subgraph app["Application Business Rules"]
-                subgraph core["Enterprise Business Rules"]
-                end
-            end
-        end
-    end
-```

--- a/docs/reference/domain.md
+++ b/docs/reference/domain.md
@@ -6,11 +6,22 @@ The **Domain** block represents the **problem space** your system is concerned w
 It contains the concepts, rules, and constraints that give meaning to your software,
 independent of frameworks, databases, delivery mechanisms, or deployment concerns.
 
-The goal of the Domain block is **clarity of intent**, not architectural purity.
+---
+## Quick summary
+
+The **Domain** block represents the **problem space** your system is concerned with. It expresses concepts, rules, and constraints independently of frameworks, databases, or delivery mechanisms.
+
+Core abstractions:
+- **Entity** — Identity matters over time (identity-based equality, version tracking)
+- **Value Object** — Immutable, defined by its values (no identity, prevents primitive obsession)
+- **Aggregate Root** — Consistency boundary that protects invariants and controls mutation
+- **Domain Errors** — Explicit representations of invalid domain states in domain terms
+
+The Domain block depends only on **Foundation** and must not depend on Application, Infrastructure, or Presentation.
+
+These are optional tools for clarity and correctness — not mandatory patterns.
 
 ---
-
-## Purpose of the Domain block
 
 The Domain block exists to:
 

--- a/docs/reference/foundation.md
+++ b/docs/reference/foundation.md
@@ -7,11 +7,25 @@ across the entire system.
 It contains **no domain logic**, **no application orchestration**, and
 **no infrastructure concerns**.
 
-Foundation exists to define **stable contracts and primitives** on top of which
-all other blocks are built.
+---
+## Quick summary
+
+The **Foundation** block provides low-level, reusable abstractions shared across the entire system. It contains **no domain logic, no application orchestration, and no infrastructure concerns** — only stable contracts and primitives.
+
+Key abstractions:
+- **Result** — Explicit outcomes (Ok/Err) without exceptions for control flow
+- **Port** — Boundaries between components (what is expected, not how implemented)
+- **Mapper** — Explicit transformations between types
+- **ValueObject** — Immutable, value-based equality objects
+- **Auto-freeze** — Automatic immutability after `__init__`
+- **Identified** — Protocol for objects carrying an identifier
+- **Messages** — Command, Event, Query (immutable, architecture-neutral)
+- **Errors** — Structured error model (message + metadata)
+- **Meta utilities** — Runtime enforcement (runtime_final, runtime_sealed, runtime_abstract)
+
+Foundation depends on nothing; all other blocks depend on Foundation.
 
 ---
-
 ## Purpose
 
 - Supply **primitive abstractions** (`Result`, `Port`, `Mapper`, `Identified`, `ValueObject`, `Message`, `Command`, `Event`, `Query`, plus error and meta utilities).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,20 @@
 # Reference
-## Overview of ForgingBlocks Components
+---
+## Quick summary
 
-```mermaid
+The **Reference** section defines the **meaning and responsibility** of each ForgingBlocks component. These pages are precise and definition-oriented — meant to be consulted as needed, not read linearly.
+
+Components:
+- **Foundation** — Core abstractions (Result, Port, Identified, Messages)
+- **Domain** — Domain modeling (Entity, ValueObject, AggregateRoot)
+- **Application** — Application layer patterns (UseCase, CommandHandler)
+- **Infrastructure** — Technical adapters and implementations
+- **Presentation** — Input/output boundaries
+- **Testing** — Testing reference and guidelines
+
+Dependencies flow inward: Domain → Application → Infrastructure/Presentation, all depending on Foundation.
+
+---
 flowchart LR
     D[Domain<br/>Problem-space concepts] -->|depends on| F[Foundation<br/>Shared abstractions]
     A[Application<br/>Coordination & behavior] -->|depends on| D
@@ -11,8 +24,9 @@ flowchart LR
     P[Presentation<br/>Input boundaries] -->|depends on| A
 ```
 
-## Reference Sections
+---
 
+## Reference Sections
 - **[Foundation](foundation.md)** - Core abstractions and utilities (Result, Port, Identified, Messages, etc.)
 - **[Domain](domain.md)** - Domain modeling abstractions (Entity, ValueObject, AggregateRoot)
 - **[Application](application.md)** - Application layer patterns (UseCase, CommandHandler)

--- a/docs/reference/infrastructure.md
+++ b/docs/reference/infrastructure.md
@@ -3,9 +3,25 @@
 
 The **Infrastructure** block provides concrete implementations of ports defined in the Application block.
 It contains all technical details.
+---
+## Quick summary
+
+The **Infrastructure** block provides **concrete implementations** of the outbound ports defined in the Application block. It handles all **technical details** — databases, APIs, message brokers, filesystems, serialization, networking — so the Application and Domain remain pure and testable.
+
+Typical implementations:
+- **Repositories** — SQL, NoSQL, in-memory, key-value stores
+- **Message Brokers** — RabbitMQ, Redis, Kafka, in-memory
+- **External API Clients** — HTTP, gRPC, third-party integrations
+- **Unit of Work** — Transaction management
+
+Characteristics:
+- May use frameworks and libraries
+- Swappable implementations
+- Contains I/O, serialization, networking, persistence
+
+Depends on **Application** (for port definitions) and **Foundation**; does not depend on Domain or Presentation.
 
 ---
-
 ## Purpose
 
 - Fulfill outbound ports using real technology.

--- a/docs/reference/presentation.md
+++ b/docs/reference/presentation.md
@@ -3,9 +3,24 @@
 
 The **Presentation** block handles all incoming interactions.
 It translates external inputs (HTTP, CLI, events) into calls to the Application block.
+---
+## Quick summary
+
+The **Presentation** block handles **all incoming interactions** — it translates external inputs (HTTP, CLI, events) into calls to the Application block. It is the **entry point** for users and external systems.
+
+Typical elements:
+- **HTTP / REST / GraphQL Handlers** — Thin request handlers delegating to Application
+- **CLI Commands** — Command-line entry points
+- **Message Listeners** — Queue or event consumer adapters
+
+Characteristics:
+- May depend on frameworks
+- No business rules
+- Designed to remain thin and delegating
+
+Depends on **Application** (for inbound ports); does not depend on Domain, Infrastructure, or Foundation directly.
 
 ---
-
 ## Purpose
 
 - Provide entry points for users or systems.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,9 +1,22 @@
 # Testing Reference
 
-This document provides a comprehensive reference for testing in the ForgingBlocks project.
+---
+## Quick summary
 
-## Quick Reference
+This document provides a **comprehensive testing reference** for ForgingBlocks. It defines the **3-tier testing architecture** and provides guidelines for writing effective tests at each level.
 
+Test tiers:
+- **Unit** (`@pytest.mark.unit`) — Pure business logic, no external deps. Fast (<1s total). Use mocks for owned contracts only.
+- **Integration** (`@pytest.mark.integration`) — Real external systems (DB, APIs, message brokers) in controlled environments. Use fakes, not mocks, for what you don't own.
+- **End-to-End** (`@pytest.mark.e2e`) — Complete workflows through presentation layer. Conditionally skipped.
+
+Key principles:
+- **Don't mock what you don't own** — Wrap external systems behind Ports, use fakes
+- **Test names describe intent** — `test_when_condition_then_outcome`
+- **Isolation by boundary, not structure** — Unit = pure logic; Integration = real externals
+- **Fast feedback** — Run unit tests frequently; integration before commit; E2E conditionally
+
+---
 ### Test Commands
 
 | Command | Purpose | Speed | Use Case |

--- a/src/forging_blocks/foundation/messages/message.py
+++ b/src/forging_blocks/foundation/messages/message.py
@@ -137,14 +137,6 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
             "message_type": self._message_type,
         }
 
-    def to_dict(self) -> dict[str, Any]:
-        """Convert metadata to dictionary representation.
-
-        Returns:
-            Dictionary representation of the metadata.
-        """
-        return self.value
-
     @property
     def _equality_components(self) -> tuple[Any, ...]:
         """Message metadata equality is based on message ID and timestamp.
@@ -153,6 +145,14 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
             Tuple containing message_id and created_at.
         """
         return (self._message_id, self._created_at)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert metadata to dictionary representation.
+
+        Returns:
+            Dictionary representation of the metadata.
+        """
+        return self.value
 
 
 class Message[MessageRawType](ValueObject[MessageRawType], ABC):
@@ -231,6 +231,17 @@ class Message[MessageRawType](ValueObject[MessageRawType], ABC):
         """
         pass
 
+    @property
+    def _equality_components(self) -> tuple[Any, ...]:
+        """Messages are equal if they have the same message ID.
+
+        Each message instance is unique, even if they have the same data.
+
+        Returns:
+            Tuple containing the message ID for equality comparison.
+        """
+        return (self._metadata.message_id,)
+
     def to_dict(self) -> dict[str, Any]:
         """Convert the message to a dictionary representation.
 
@@ -243,14 +254,3 @@ class Message[MessageRawType](ValueObject[MessageRawType], ABC):
             "metadata": self._metadata.to_dict(),
             "payload": self._payload,
         }
-
-    @property
-    def _equality_components(self) -> tuple[Any, ...]:
-        """Messages are equal if they have the same message ID.
-
-        Each message instance is unique, even if they have the same data.
-
-        Returns:
-            Tuple containing the message ID for equality comparison.
-        """
-        return (self._metadata.message_id,)


### PR DESCRIPTION
- **docs: replace :class: with backticks in result_access_error.py**
- **docs: replace :class: and :meth: with backticks in result/ok.py**
- **docs: replace :class: with backticks in result/err.py**
- **docs: replace :class: with backticks in error.py**
- **docs: replace :class: with backticks in error.py**
- **docs: replace :class: and :meth: with backticks in multiple files**
- **style(foundation): ruff docstyle**
- **style: order Message method**
- **docs(contributing): move quick summary to top and rename from 'In short'**
- **docs(index): add quick summary section**
- **docs(reference): add quick summary to reference index**
- **docs(reference): add quick summary to foundation**
- **docs(reference): add quick summary to domain**
- **docs(reference): add quick summary to application**
- **docs(reference): add quick summary to infrastructure**
- **docs(reference): add quick summary to presentation**
- **docs(reference): add quick summary to testing reference**
- **docs(guide): add quick summary and remove old 'In short' section**
- **docs(guide): add quick summary to getting started**
- **docs(guide): add quick summary to principles**
- **docs(guide): add quick summary to examples**
- **docs(guide): add quick summary to example tests**
- **docs(guide): add quick summary to architecture overview**
- **docs(guide): add quick summary to recommended blocks structure**
- **docs(guide): add quick summary to testing guide**
- **docs(arch-styles): add quick summary to architectural styles index**
- **docs(arch-styles): add quick summary and fix structure for clean architecture**
- **docs(arch-styles): add quick summary and fix structure for hexagonal architecture**
- **docs(arch-styles): add quick summary and fix structure for layered architecture**
- **docs(arch-styles): add quick summary and fix structure for CQRS**
- **docs(arch-styles): add quick summary and fix structure for event-driven**
- **docs(contributing): add quick summary and remove duplicate 'In short' section**
- **docs(contributing): add quick summary and separators to contributing index**
- **docs(reference): add quick summary to clean architecture reference**
