### PR TITLE
refactor(message-bus): replace inspect.iscoroutine with asyncio.iscoroutine

### DIFF
--- a/src/forging_blocks/infrastructure/message_bus/in_memory_message_bus.py
+++ b/src/forging_blocks/infrastructure/message_bus/in_memory_message_bus.py
@@ -4,9 +4,7 @@ Provides a simple synchronous dispatch mechanism that routes messages
 to registered handlers based on message type.
 """
 
-from __future__ import annotations
-
-import inspect
+import asyncio
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -67,6 +65,6 @@ class InMemoryMessageBus[MessageType: Message[Any], MessageBusResultType](
         """
         handler = self._handlers[type(message)]
         result = handler(message)
-        if inspect.iscoroutine(result):
+        if asyncio.iscoroutine(result):
             result = await result
         return cast(MessageBusResultType, result)


### PR DESCRIPTION
Use asyncio.iscoroutine() which is more idiomatic for checking coroutine
objects in asyncio code, as recommended in issue #232.
