### PR TITLE
chore/remove depecated aliases

### DIFF
--- a/docs/guide/recommended_blocks_structure.md
+++ b/docs/guide/recommended_blocks_structure.md
@@ -88,7 +88,7 @@ Think of blocks as **named boundaries** that you are free to use or ignore depen
 Examples:
 
 - `Result`, `Ok`, `Err`
-- `Port` and port-related protocols (`InboundPort`, `OutboundPort`, `InputPort`, `OutputPort`)
+- `Port` and port-related protocols (`InboundPort`, `OutboundPort`)
 - `Identified` protocol for objects carrying an identity
 - `Mapper` protocol for structured transformation
 - `Debuggable` protocol for consistent debug representations

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ ForgingBlocks simply provides the building blocks that help you write decoupled,
 | **Mapper** | Transforms values from one type into another in an observable way. |
 | **Identified** | Protocol for any object that carries an identifier. |
 | **Debuggable** | Protocol ensuring an object exposes a clear, consistent debug representation. |
-| **Port / InboundPort / OutboundPort / InputPort / OutputPort** | Define explicit communication boundaries. |
+| **Port / InboundPort / OutboundPort** | Define explicit communication boundaries. |
 | **ValueObject** | Base class for immutable concepts defined entirely by their values. |
 | **Error / ValidationError / RuleViolationError / FieldErrors / CombinedErrors** | Structured, composable error model. |
 | **Message / Command / Event / Query** | Express intent, facts, and queries within the problem space. |

--- a/docs/reference/foundation.md
+++ b/docs/reference/foundation.md
@@ -167,12 +167,12 @@ They enable replacement, testing, and decoupling without imposing an architectur
 input and output type. The concrete meaning of a port is defined by the
 components that extend it.
 
-In addition to the base `Port`, Foundation exposes two pairs of role-marking
+In addition to the base `Port`, Foundation exposes two role-marking
 aliases that you can use to give a boundary a more specific semantic name:
 
-- `InboundPort` and `InputPort` describe boundaries that **accept input** from
+- `InboundPort` describes boundaries that **accept input** from
   the outside world.
-- `OutboundPort` and `OutputPort` describe boundaries that **produce output**
+- `OutboundPort` describes boundaries that **produce output**
   towards the outside world.
 
 These aliases are intentionally not prescriptive.

--- a/scripts/release/application/ports/outbound/pull_request_service.py
+++ b/scripts/release/application/ports/outbound/pull_request_service.py
@@ -1,25 +1,22 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 
-from forging_blocks.foundation.ports import OutputPort
+from forging_blocks.foundation.ports import OutboundPort
 from scripts.release.domain.entities import ReleasePullRequest
 
 
 @dataclass(frozen=True)
 class OpenPullRequestOutput:
-    """DTO representing the output of creating a pull request.
-    """
+    """DTO representing the output of creating a pull request."""
 
     pr_id: str | None
     url: str | None
 
 
-class PullRequestService(OutputPort[ReleasePullRequest, OpenPullRequestOutput]):
-    """Service that manages pull request creation in remote repository.
-    """
+class PullRequestService(OutboundPort[ReleasePullRequest, OpenPullRequestOutput]):
+    """Service that manages pull request creation in remote repository."""
 
     @abstractmethod
     def open(self, pull_request: ReleasePullRequest) -> OpenPullRequestOutput:
-        """Open a pull request and return its details.
-        """
+        """Open a pull request and return its details."""
         ...

--- a/scripts/release/application/ports/outbound/version_control.py
+++ b/scripts/release/application/ports/outbound/version_control.py
@@ -1,10 +1,10 @@
 from abc import abstractmethod
 
-from forging_blocks.foundation import OutputPort
+from forging_blocks.foundation.ports import OutboundPort
 from scripts.release.domain.value_objects import ReleaseBranchName
 
 
-class VersionControl(OutputPort[ReleaseBranchName, bool]):
+class VersionControl(OutboundPort[ReleaseBranchName, bool]):
     """Abstracts version control operations required by the release workflow.
 
     Must be non-interactive. All methods must raise on failure.

--- a/scripts/release/application/ports/outbound/versioning_service.py
+++ b/scripts/release/application/ports/outbound/versioning_service.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 
-from forging_blocks.foundation.ports import OutputPort
+from forging_blocks.foundation.ports import OutboundPort
 from scripts.release.domain.value_objects import (
     ReleaseLevel,
     ReleaseVersion,
 )
 
 
-class VersioningService(OutputPort[str, None], ABC):
+class VersioningService(OutboundPort[str, None], ABC):
     """Computes and applies semantic versions to the package definition.
 
     Must be non-interactive and deterministic.
@@ -15,8 +15,7 @@ class VersioningService(OutputPort[str, None], ABC):
 
     @abstractmethod
     def current_version(self) -> ReleaseVersion:
-        """Read the currently configured version (e.g., from pyproject.toml via Poetry).
-        """
+        """Read the currently configured version (e.g., from pyproject.toml via Poetry)."""
         ...
 
     @abstractmethod
@@ -24,8 +23,7 @@ class VersioningService(OutputPort[str, None], ABC):
         self,
         level: ReleaseLevel,
     ) -> ReleaseVersion:
-        """Compute the next version without mutating state.
-        """
+        """Compute the next version without mutating state."""
         ...
 
     @abstractmethod
@@ -35,8 +33,7 @@ class VersioningService(OutputPort[str, None], ABC):
         *,
         dry_run: bool = False,
     ) -> None:
-        """Mutate version to the given target.
-        """
+        """Mutate version to the given target."""
         ...
 
     @abstractmethod

--- a/src/forging_blocks/foundation/__init__.py
+++ b/src/forging_blocks/foundation/__init__.py
@@ -22,9 +22,7 @@ from .messages import Command, Event, Message, Query
 from .meta import FinalABCMeta, FinalMeta, runtime_final
 from .ports import (
     InboundPort,
-    InputPort,
     OutboundPort,
-    OutputPort,
     Port,
 )
 from .result import Err, Ok, Result
@@ -34,8 +32,6 @@ __all__ = [
     "Port",
     "InboundPort",
     "OutboundPort",
-    "InputPort",
-    "OutputPort",
     "Mapper",
     "Result",
     "Ok",

--- a/src/forging_blocks/foundation/ports.py
+++ b/src/forging_blocks/foundation/ports.py
@@ -23,11 +23,3 @@ class InboundPort[InputType, OutputType](Port[InputType, OutputType], Protocol):
 
 class OutboundPort[InputType, OutputType](Port[InputType, OutputType], Protocol):
     """Alias for Port used as an outbound marker."""
-
-
-class InputPort[InputType, OutputType](InboundPort[InputType, OutputType], Protocol):
-    """Alias for InboundPort."""
-
-
-class OutputPort[InputType, OutputType](OutboundPort[InputType, OutputType], Protocol):
-    """Alias for OutboundPort."""


### PR DESCRIPTION
- **chore(foundation): remove InputPort/OutputPort from exports**
- **chore(foundation): remove InputPort/OutputPort class definitions**
- **docs(index): remove InputPort/OutputPort from Core Concepts table**
- **docs(guide): remove InputPort/OutputPort from Foundation block list**
- **docs(reference): remove InputPort/OutputPort aliases from Port documentation**
- **chore(scripts): replace OutputPort with OutboundPort in PullRequestService**
- **chore(scripts): replace OutputPort with OutboundPort in VersionControl**
- **chore(scripts): replace OutputPort with OutboundPort in VersioningService**
