### PR TITLE
chore/loose to strong type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ fix = true
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "C4"]
 ignore = ["B008"]  # Only ignore function calls in argument defaults
-per-file-ignores = {"tests/**" = ["E501", "B011"]}  # Allow long lines and assert False in tests
+per-file-ignores = {"tests/**" = ["E501", "B011", "B009"]}  # Allow long lines, assert False, and getattr in tests
 
 [tool.ruff.lint.isort]
 known-first-party = ["forging_blocks"]

--- a/scripts/generate_autodoc_pages.py
+++ b/scripts/generate_autodoc_pages.py
@@ -91,7 +91,7 @@ def build_autodoc_section(files: list[Path], indent: str = "      ") -> str:
 
         # Sort: None (direct) first, then alphabetically
         for sublayer, entries in sorted(
-            subgroups.items(), key=lambda x: ("" if x[0] is None else x[0])
+            subgroups.items(), key=lambda x: "" if x[0] is None else x[0]
         ):
             if sublayer is None:
                 # Direct entries

--- a/scripts/order_members.py
+++ b/scripts/order_members.py
@@ -226,9 +226,7 @@ class ReorderClassMembers(cst.CSTTransformer):
         )
 
         new_body = [stmt for _, stmt in reordered]
-        return updated_node.with_changes(
-            body=updated_node.body.with_changes(body=new_body)
-        )
+        return updated_node.with_changes(body=updated_node.body.with_changes(body=new_body))
 
 
 def reorder_file(path: Path) -> bool:

--- a/scripts/release/application/errors/tag_already_exists_error.py
+++ b/scripts/release/application/errors/tag_already_exists_error.py
@@ -4,8 +4,7 @@ from forging_blocks.foundation.errors.rule_violation_error import RuleViolationE
 
 # RuntimeError
 class TagAlreadyExistsError(RuleViolationError):
-    """Raised when attempting to create a release with an existing tag.
-    """
+    """Raised when attempting to create a release with an existing tag."""
 
     def __init__(self, tag_name: str) -> None:
         message = ErrorMessage(f"Tag '{tag_name}' already exists.")

--- a/scripts/release/application/ports/inbound/open_pull_request_command_handler.py
+++ b/scripts/release/application/ports/inbound/open_pull_request_command_handler.py
@@ -13,4 +13,4 @@ class OpenPullRequestCommandHandler(Protocol):
 
         :return: None
         """
-        ...
+        pass

--- a/scripts/release/application/ports/inbound/open_release_pull_request_use_case.py
+++ b/scripts/release/application/ports/inbound/open_release_pull_request_use_case.py
@@ -27,8 +27,7 @@ class OpenReleasePullRequestInput:
 
 @dataclass(frozen=True)
 class OpenReleasePullRequestOutput:
-    """Response DTO for creating a release pull request.
-    """
+    """Response DTO for creating a release pull request."""
 
     pr_id: str | None
     url: str | None

--- a/scripts/release/application/ports/outbound/release_command_bus.py
+++ b/scripts/release/application/ports/outbound/release_command_bus.py
@@ -26,7 +26,6 @@ class ReleaseCommandBus(MessageBus[CommandType, None], Generic[CommandType], Pro
             - Handlers should be asynchronous.
             - Registration is typically done at application startup.
         """
-        ...
 
     async def send(self, message: CommandType) -> None:
         """Publish a release-related domain command.
@@ -38,4 +37,3 @@ class ReleaseCommandBus(MessageBus[CommandType, None], Generic[CommandType], Pro
             - Asynchronous and fire-and-forget.
             - Delivery reliability depends on the CommandBus implementation.
         """
-        ...

--- a/scripts/release/application/ports/outbound/release_command_bus.py
+++ b/scripts/release/application/ports/outbound/release_command_bus.py
@@ -1,6 +1,6 @@
 from typing import Any, Generic, Protocol, TypeVar
 
-from forging_blocks.application.ports.inbound.message_handler import CommandHandler
+from forging_blocks.application.ports.inbound.message_handler import MessageHandler
 from forging_blocks.application.ports.outbound.message_bus import MessageBus
 from forging_blocks.foundation.messages.command import Command
 
@@ -14,9 +14,7 @@ class ReleaseCommandBus(MessageBus[CommandType, None], Generic[CommandType], Pro
     """
 
     async def register[CT: Command[Any]](
-        self,
-        command_type: type[CT],
-        handler: CommandHandler[CT]
+        self, command_type: type[CT], handler: MessageHandler[CT, None]
     ) -> None:
         """Register a message handler for a specific message type.
 

--- a/scripts/release/application/services/prepare_release_service.py
+++ b/scripts/release/application/services/prepare_release_service.py
@@ -96,9 +96,7 @@ class PrepareReleaseService(PrepareReleaseUseCase):
         )
         await self._message_bus.send(command)
 
-    async def _prepare_release_transactionally(
-        self, context: ReleaseContext
-    ) -> list[str]:
+    async def _prepare_release_transactionally(self, context: ReleaseContext) -> list[str]:
         if context.dry_run:
             return await self._prepare_release_dry_run(context)
 
@@ -119,9 +117,7 @@ class PrepareReleaseService(PrepareReleaseUseCase):
 
         return changelog_entries
 
-    async def _prepare_release_dry_run(
-        self, context: ReleaseContext
-    ) -> list[str]:
+    async def _prepare_release_dry_run(self, context: ReleaseContext) -> list[str]:
         self._branch_handling(context, dry_run=True)
         self._versioning_service.apply_version(context.version, dry_run=True)
         changelog_entries = await self._generate_changelog(context)

--- a/scripts/release/domain/commands/open_pull_request_command.py
+++ b/scripts/release/domain/commands/open_pull_request_command.py
@@ -1,4 +1,4 @@
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 from forging_blocks.foundation.messages.command import Command
 
@@ -35,5 +35,5 @@ class OpenPullRequestCommand(Command[PayloadType]):
         return self._dry_run
 
     @property
-    def _payload(self) -> PayloadType:
-        return self._value
+    def _payload(self) -> dict[str, object]:
+        return cast(dict[str, object], self._value)

--- a/scripts/release/domain/errors/invalid_release_level_error.py
+++ b/scripts/release/domain/errors/invalid_release_level_error.py
@@ -4,7 +4,5 @@ from forging_blocks.foundation import ErrorMessage, ValidationError
 class InvalidReleaseLevelError(ValidationError):
     def __init__(self, value: str) -> None:
         super().__init__(
-            ErrorMessage(
-                f"Invalid release level '{value}'. Allowed values: patch, minor, major."
-            )
+            ErrorMessage(f"Invalid release level '{value}'. Allowed values: patch, minor, major.")
         )

--- a/scripts/release/domain/errors/invalid_release_version_error.py
+++ b/scripts/release/domain/errors/invalid_release_version_error.py
@@ -4,5 +4,7 @@ from forging_blocks.foundation import ErrorMessage, ErrorMetadata, ValidationErr
 class InvalidReleaseVersionError(ValidationError):
     def __init__(self, release_version: str) -> None:
         message = ErrorMessage(f"'{release_version}' should be bigger than v0.0.0")
-        metadata = ErrorMetadata(context={"release_version": release_version})
+        metadata: ErrorMetadata[dict[str, object]] = ErrorMetadata(
+            context={"release_version": release_version}
+        )
         super().__init__(message, metadata)

--- a/scripts/release/domain/errors/invalid_tag_name_error.py
+++ b/scripts/release/domain/errors/invalid_tag_name_error.py
@@ -4,7 +4,5 @@ from forging_blocks.foundation import ErrorMessage, ValidationError
 class InvalidTagNameError(ValidationError):
     def __init__(self, value: str) -> None:
         super().__init__(
-            ErrorMessage(
-                f"Invalid tag name '{value}'. Tags must start with 'v<version>'."
-            )
+            ErrorMessage(f"Invalid tag name '{value}'. Tags must start with 'v<version>'.")
         )

--- a/scripts/release/infrastructure/bus/in_memory_release_command_bus.py
+++ b/scripts/release/infrastructure/bus/in_memory_release_command_bus.py
@@ -1,24 +1,24 @@
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
-from forging_blocks.application.ports.inbound.message_handler import CommandHandler
+from forging_blocks.application.ports.inbound.message_handler import MessageHandler
 from forging_blocks.foundation.messages.command import Command
 from scripts.release.application.ports.outbound import ReleaseCommandBus
 
-CommandSubscriberType: TypeAlias = dict[type[Command[Any]], CommandHandler[Command[Any]]]
+CommandSubscriberType: TypeAlias = dict[type[Command[Any]], MessageHandler[Command[Any], None]]
 
 
 class InMemoryReleaseCommandBus(ReleaseCommandBus[Command[Any]]):
     def __init__(self) -> None:
-        self._subscribers: dict[type[Command[Any]], CommandHandler[Command[Any]]] = {}
+        self._subscribers: dict[type[Command[Any]], MessageHandler[Command[Any], None]] = {}
 
     async def dispatch(self, message: Command[Any]) -> None:
         """Dispatch a message to the registered handler."""
         await self.send(message)
 
     async def register[CT: Command[Any]](
-        self, command_type: type[CT], handler: CommandHandler[CT]
+        self, command_type: type[CT], handler: MessageHandler[CT, None]
     ) -> None:
-        self._subscribers[command_type] = handler  # type: ignore[reportArgumentType]
+        self._subscribers[command_type] = cast(MessageHandler[Command[Any], None], handler)
 
     async def send(self, message: Command[Any]) -> None:
         handler = self._subscribers[type(message)]

--- a/scripts/release/infrastructure/changelog/git_cliff_changelog_generator.py
+++ b/scripts/release/infrastructure/changelog/git_cliff_changelog_generator.py
@@ -157,9 +157,7 @@ class GitCliffChangelogGenerator(ChangelogGenerator):
 
         return merged_new + existing_without_unreleased
 
-    def _parse_version_section(
-        self, content: str
-    ) -> tuple[str, list[tuple[str, str]]]:
+    def _parse_version_section(self, content: str) -> tuple[str, list[tuple[str, str]]]:
         lines = content.split("\n")
         header_idx = 0
         for i, line in enumerate(lines):

--- a/scripts/release/infrastructure/container.py
+++ b/scripts/release/infrastructure/container.py
@@ -68,4 +68,4 @@ class Container:
         )
         open_pull_request_handler = OpenPullRequestHandler(open_pull_request_service)
 
-        await self._message_bus.register(OpenPullRequestCommand, open_pull_request_handler)  # type: ignore[reportArgumentType]
+        await self._message_bus.register(OpenPullRequestCommand, open_pull_request_handler)

--- a/scripts/release/infrastructure/handlers/__init__.py
+++ b/scripts/release/infrastructure/handlers/__init__.py
@@ -1,5 +1,3 @@
 from .open_pull_request_handler import OpenPullRequestHandler
 
-__all__ = (
-    "OpenPullRequestHandler",
-)
+__all__ = ("OpenPullRequestHandler",)

--- a/scripts/release/presentation/parsers/__init__.py
+++ b/scripts/release/presentation/parsers/__init__.py
@@ -1,5 +1,3 @@
 from .release_cli_parser import ReleaseCliParser
 
-__all__ = (
-    "ReleaseCliParser",
-)
+__all__ = ("ReleaseCliParser",)

--- a/src/forging_blocks/application/errors/unit_of_work_error.py
+++ b/src/forging_blocks/application/errors/unit_of_work_error.py
@@ -1,7 +1,7 @@
 from forging_blocks.foundation.errors.error import Error
 
 
-class UnitOfWorkError(Error):
+class UnitOfWorkError(Error[dict[str, object]]):
     """Error raised when a Unit of Work operation fails."""
 
     pass

--- a/src/forging_blocks/application/ports/inbound/message_handler.py
+++ b/src/forging_blocks/application/ports/inbound/message_handler.py
@@ -16,7 +16,7 @@ Non-Responsibilities:
     - Persistence (handled by repositories).
 """
 
-from typing import Any, Protocol, TypeAlias, TypeVar
+from typing import Protocol, TypeVar
 
 from forging_blocks.foundation.messages.command import Command
 from forging_blocks.foundation.messages.event import Event
@@ -24,13 +24,17 @@ from forging_blocks.foundation.messages.message import Message
 from forging_blocks.foundation.messages.query import Query
 from forging_blocks.foundation.ports import InboundPort
 
-CommandType = TypeVar("CommandType", contravariant=True, bound=Command[Any])
-QueryType = TypeVar("QueryType", contravariant=True, bound=Query)
-EventType = TypeVar("EventType", contravariant=True, bound=Event[Any])
+CommandPayloadType = TypeVar("CommandPayloadType", contravariant=True)
+QueryPayloadType = TypeVar("QueryPayloadType", contravariant=True)
+EventPayloadType = TypeVar("EventPayloadType", contravariant=True)
 QueryResultType = TypeVar("QueryResultType", covariant=True)
 
+CommandType = TypeVar("CommandType", contravariant=True, bound=Command[object])
+QueryType = TypeVar("QueryType", contravariant=True, bound=Query[object])
+EventType = TypeVar("EventType", contravariant=True, bound=Event[object])
 
-class MessageHandler[MessageType: Message[Any], MessageHandlerResultType](
+
+class MessageHandler[MessageType: Message[object], MessageHandlerResultType](
     InboundPort[MessageType, MessageHandlerResultType],
     Protocol,
 ):
@@ -66,6 +70,28 @@ class MessageHandler[MessageType: Message[Any], MessageHandlerResultType](
         ...
 
 
-CommandHandler: TypeAlias = MessageHandler[CommandType, None]
-QueryHandler: TypeAlias = MessageHandler[QueryType, QueryResultType]
-EventHandler: TypeAlias = MessageHandler[EventType, None]
+class CommandHandler[CommandPayloadType](
+    MessageHandler[Command[CommandPayloadType], None],
+    Protocol,
+):
+    """Inbound port for handling commands asynchronously."""
+
+    ...
+
+
+class QueryHandler[QueryPayloadType, QueryResultType](
+    MessageHandler[Query[QueryPayloadType], QueryResultType],
+    Protocol,
+):
+    """Inbound port for handling queries asynchronously."""
+
+    ...
+
+
+class EventHandler[EventPayloadType](
+    MessageHandler[Event[EventPayloadType], None],
+    Protocol,
+):
+    """Inbound port for handling events asynchronously."""
+
+    ...

--- a/src/forging_blocks/application/ports/inbound/message_handler.py
+++ b/src/forging_blocks/application/ports/inbound/message_handler.py
@@ -76,8 +76,6 @@ class CommandHandler[CommandPayloadType](
 ):
     """Inbound port for handling commands asynchronously."""
 
-    ...
-
 
 class QueryHandler[QueryPayloadType, QueryResultType](
     MessageHandler[Query[QueryPayloadType], QueryResultType],
@@ -85,13 +83,9 @@ class QueryHandler[QueryPayloadType, QueryResultType](
 ):
     """Inbound port for handling queries asynchronously."""
 
-    ...
-
 
 class EventHandler[EventPayloadType](
     MessageHandler[Event[EventPayloadType], None],
     Protocol,
 ):
     """Inbound port for handling events asynchronously."""
-
-    ...

--- a/src/forging_blocks/application/ports/outbound/command_sender.py
+++ b/src/forging_blocks/application/ports/outbound/command_sender.py
@@ -13,14 +13,12 @@ Non-Responsibilities:
     - Serialization or transport concerns.
 """
 
-from typing import Any
-
 from forging_blocks.application.ports.outbound.message_bus import MessageBus
 from forging_blocks.foundation.messages.command import Command
 from forging_blocks.foundation.ports import OutboundPort
 
 
-class CommandSender(OutboundPort[Command[Any], None]):
+class CommandSender[CommandPayloadType](OutboundPort[Command[CommandPayloadType], None]):
     """Outbound port for asynchronously sending command messages.
 
     The CommandSender delegates message dispatching to a MessageBus. It is
@@ -28,10 +26,10 @@ class CommandSender(OutboundPort[Command[Any], None]):
     operations in other parts of the system.
     """
 
-    def __init__(self, message_bus: MessageBus[Command[Any], None]) -> None:
+    def __init__(self, message_bus: MessageBus[Command[CommandPayloadType], None]) -> None:
         self._message_bus = message_bus
 
-    async def send(self, command: Command[Any]) -> None:
+    async def send(self, command: Command[CommandPayloadType]) -> None:
         """Send a command asynchronously.
 
         Args:

--- a/src/forging_blocks/application/ports/outbound/event_publisher.py
+++ b/src/forging_blocks/application/ports/outbound/event_publisher.py
@@ -13,14 +13,12 @@ Non-Responsibilities:
     - Guarantee ordering or durability.
 """
 
-from typing import Any
-
 from forging_blocks.application.ports.outbound.message_bus import MessageBus
 from forging_blocks.foundation.messages.event import Event
 from forging_blocks.foundation.ports import OutboundPort
 
 
-class EventPublisher(OutboundPort[Event[Any], None]):
+class EventPublisher[EventPayloadType](OutboundPort[Event[EventPayloadType], None]):
     """Outbound port for publishing domain events asynchronously.
 
     An EventPublisher provides an abstraction over event transport. Use cases
@@ -28,10 +26,10 @@ class EventPublisher(OutboundPort[Event[Any], None]):
     transitions. The underlying MessageBus determines the delivery semantics.
     """
 
-    def __init__(self, message_bus: MessageBus[Event[Any], None]) -> None:
+    def __init__(self, message_bus: MessageBus[Event[EventPayloadType], None]) -> None:
         self._message_bus = message_bus
 
-    async def publish(self, event: Event[Any]) -> None:
+    async def publish(self, event: Event[EventPayloadType]) -> None:
         """Publish a domain event.
 
         Args:

--- a/src/forging_blocks/application/ports/outbound/query_fetcher.py
+++ b/src/forging_blocks/application/ports/outbound/query_fetcher.py
@@ -18,20 +18,22 @@ from forging_blocks.foundation.messages.query import Query
 from forging_blocks.foundation.ports import OutboundPort
 
 
-class QueryFetcher[QueryFetcherResult](
-    OutboundPort[Query, QueryFetcherResult],
+class QueryFetcher[QueryPayloadType, QueryFetcherResult](
+    OutboundPort[Query[QueryPayloadType], QueryFetcherResult],
 ):
     """Outbound port for dispatching query messages.
 
     The QueryFetcher abstracts query execution through a MessageBus. It does
     not apply any interpretation to the returned data; shaping is the query
-    handler’s responsibility.
+    handler's responsibility.
     """
 
-    def __init__(self, message_bus: MessageBus[Query, QueryFetcherResult]) -> None:
+    def __init__(
+        self, message_bus: MessageBus[Query[QueryPayloadType], QueryFetcherResult]
+    ) -> None:
         self._message_bus = message_bus
 
-    async def fetch(self, query: Query) -> QueryFetcherResult:
+    async def fetch(self, query: Query[QueryPayloadType]) -> QueryFetcherResult:
         """Fetch the result of a query.
 
         Args:

--- a/src/forging_blocks/application/ports/outbound/repository.py
+++ b/src/forging_blocks/application/ports/outbound/repository.py
@@ -50,7 +50,6 @@ class ReadOnlyRepository[TReadAggregateRoot, TId](Protocol):
             A sequence of aggregate or read model instances.
 
         Notes:
-            Data sources may differ from command-side storage.
         """
         ...
 
@@ -71,7 +70,7 @@ class WriteOnlyRepository[TWriteAggregateRoot, TWriteId](Protocol):
         Raises:
             RepositoryError: If deletion fails.
         """
-        ...
+        pass
 
     async def save(self, aggregate: TWriteAggregateRoot) -> None:
         """Persist an aggregate instance.
@@ -79,7 +78,7 @@ class WriteOnlyRepository[TWriteAggregateRoot, TWriteId](Protocol):
         Args:
             aggregate: The aggregate to save.
         """
-        ...
+        pass
 
 
 class Repository[TAggregateRoot, TId](

--- a/src/forging_blocks/domain/aggregate_root/aggregate_root.py
+++ b/src/forging_blocks/domain/aggregate_root/aggregate_root.py
@@ -2,7 +2,6 @@
 
 from abc import abstractmethod
 from collections.abc import Hashable
-from typing import Any
 
 from forging_blocks.domain.entity import Entity
 from forging_blocks.domain.errors.entity_id_none_error import EntityIdNoneError
@@ -12,7 +11,7 @@ from forging_blocks.foundation.messages.event import Event
 from .aggregate_version import AggregateVersion
 
 
-class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
+class AggregateRoot[TId: Hashable, EventPayloadType = object](Entity[TId], metaclass=FinalABCMeta):
     """Base class for Aggregate Roots in a Domain-Driven Design context.
 
     An Aggregate Root represents the entry point for manipulating
@@ -28,7 +27,7 @@ class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
     def __init__(self, aggregate_id: TId, version: AggregateVersion | None = None) -> None:
         self._validate_identity(aggregate_id)
         self._version = version or AggregateVersion(0)
-        self._uncommitted_events: list[Event[Any]] = []
+        self._uncommitted_events: list[Event[EventPayloadType]] = []
         super().__init__(aggregate_id)
 
     @runtime_final
@@ -56,12 +55,12 @@ class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
         return self._version
 
     @property
-    def uncommitted_changes(self) -> list[Event[Any]]:
+    def uncommitted_changes(self) -> list[Event[EventPayloadType]]:
         """Return a copy of uncommitted domain events recorded by this aggregate."""
         return self._uncommitted_events.copy()
 
     @runtime_final
-    def collect_events(self) -> list[Event[Any]]:
+    def collect_events(self) -> list[Event[EventPayloadType]]:
         """Drain uncommitted events for the dispatcher.
 
         Called by the Unit of Work or repository after persistence.
@@ -81,7 +80,7 @@ class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
         self._uncommitted_events.clear()
 
     @runtime_final
-    def record_event(self, domain_event: Event[Any]) -> None:
+    def record_event(self, domain_event: Event[EventPayloadType]) -> None:
         """Record an event that occurred outside aggregate state mutation.
 
         Use for integration events or application-layer concerns
@@ -90,7 +89,7 @@ class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
         self._uncommitted_events.append(domain_event)
 
     @runtime_final
-    def apply(self, event: Event[Any]) -> None:
+    def apply(self, event: Event[EventPayloadType]) -> None:
         """Apply a new domain event during command processing.
 
         Delegates mutation to _handle(), increments version,
@@ -106,7 +105,7 @@ class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
         self._uncommitted_events.append(event)
 
     @runtime_final
-    def replay(self, event: Event[Any]) -> None:
+    def replay(self, event: Event[EventPayloadType]) -> None:
         """Reconstitute aggregate state from a stored event.
 
         Intended for event store reconstitution only.
@@ -120,7 +119,7 @@ class AggregateRoot[TId: Hashable](Entity[TId], metaclass=FinalABCMeta):
         self._version = self._version.increment()
 
     @abstractmethod
-    def _handle(self, event: Event[Any]) -> None:
+    def _handle(self, event: Event[EventPayloadType]) -> None:
         """Mutate aggregate state in response to an event.
 
         Implemented by concrete subclasses. Called exclusively

--- a/src/forging_blocks/domain/entity.py
+++ b/src/forging_blocks/domain/entity.py
@@ -3,7 +3,7 @@
 import inspect
 from abc import ABC
 from collections.abc import Hashable
-from typing import Any, cast
+from typing import Any
 
 from forging_blocks.domain.errors import (
     DraftEntityIsNotHashableError,
@@ -65,12 +65,12 @@ class Entity[TId: Hashable](ABC):
         if type(self) is not type(other):
             return False
 
-        other_entty = cast(Entity[TId], other)
+        other_entity: Entity[TId] = other  # type: ignore[assignment]
 
-        if self._id is None or other_entty._id is None:
-            return self is other_entty
+        if self._id is None or other_entity._id is None:
+            return self is other_entity
 
-        return self._id == other_entty._id
+        return self._id == other_entity._id
 
     def __hash__(self) -> int:
         """Return the hash based on the entity's identifier.

--- a/src/forging_blocks/domain/errors/draft_entity_is_not_hashable_error.py
+++ b/src/forging_blocks/domain/errors/draft_entity_is_not_hashable_error.py
@@ -6,7 +6,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage
 from forging_blocks.foundation.errors.error import Error
 
 
-class DraftEntityIsNotHashableError(Error):
+class DraftEntityIsNotHashableError(Error[dict[str, object]]):
     """Raised because draft entities are not hashable."""
 
     @classmethod

--- a/src/forging_blocks/domain/errors/entity_id_deletion_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_deletion_error.py
@@ -4,7 +4,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
 from forging_blocks.foundation.errors.error import Error
 
 
-class EntityIdDeletionError(Error):
+class EntityIdDeletionError(Error[dict[str, object]]):
     """Raised when there is an attempt to delete an entity's identifier."""
 
     def __init__(self, class_name: str) -> None:
@@ -16,7 +16,7 @@ class EntityIdDeletionError(Error):
         message = ErrorMessage(
             f"Cannot delete 'id' of {class_name} as it defines the entity's identity."
         )
-        metadata = ErrorMetadata(
+        metadata = ErrorMetadata[dict[str, object]](
             {
                 "class_name": class_name,
                 "attribute_name": "id",

--- a/src/forging_blocks/domain/errors/entity_id_modification_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_modification_error.py
@@ -4,7 +4,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
 from forging_blocks.foundation.errors.error import Error
 
 
-class EntityIdModificationError(Error):
+class EntityIdModificationError(Error[dict[str, object]]):
     """Raised when there is an attempt to modify an entity's identifier after it has been set."""
 
     def __init__(self, class_name: str, attribute_name: str, current_value: object) -> None:
@@ -19,7 +19,7 @@ class EntityIdModificationError(Error):
             f"Cannot modify '{attribute_name}' of {class_name} once set "
             f"(current value={current_value!r})."
         )
-        metadata = ErrorMetadata(
+        metadata = ErrorMetadata[dict[str, object]](
             {
                 "class_name": class_name,
                 "attribute_name": attribute_name,

--- a/src/forging_blocks/domain/errors/entity_id_none_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_none_error.py
@@ -9,7 +9,7 @@ class EntityIdNoneError(NoneNotAllowedError):
 
     def __init__(self, entity_class_name: str) -> None:
         message = ErrorMessage(f"Entity ID have to be defined for '{entity_class_name}'.")
-        metadata = ErrorMetadata(
+        metadata = ErrorMetadata[dict[str, object]](
             context={
                 "entity_class_name": entity_class_name,
             }

--- a/src/forging_blocks/foundation/errors/cant_modify_immutable_attribute_error.py
+++ b/src/forging_blocks/foundation/errors/cant_modify_immutable_attribute_error.py
@@ -4,7 +4,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
 from forging_blocks.foundation.errors.error import Error
 
 
-class CantModifyImmutableAttributeError(Error):
+class CantModifyImmutableAttributeError(Error[dict[str, object]]):
     """Raised when there is an attempt to modify an immutable attribute of an object."""
 
     def __init__(self, class_name: str, attribute_name: str):
@@ -17,7 +17,7 @@ class CantModifyImmutableAttributeError(Error):
         message = ErrorMessage(
             f"Cannot modify immutable attribute '{attribute_name}' of class '{class_name}'."
         )
-        metadata = ErrorMetadata(
+        metadata = ErrorMetadata[dict[str, object]](
             {
                 "class_name": class_name,
                 "attribute_name": attribute_name,

--- a/src/forging_blocks/foundation/errors/combined_errors.py
+++ b/src/forging_blocks/foundation/errors/combined_errors.py
@@ -9,7 +9,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage
 from forging_blocks.foundation.errors.error import Error
 
 
-class CombinedErrors[ErrorType: Error](Error):
+class CombinedErrors[ErrorType: Error[dict[str, object]]](Error[dict[str, object]]):
     """Base class for combining multiple errors into one."""
 
     def __init__(self, errors: Iterable[ErrorType]) -> None:

--- a/src/forging_blocks/foundation/errors/core.py
+++ b/src/forging_blocks/foundation/errors/core.py
@@ -3,8 +3,9 @@
 Defines fundamental data structures for error messages, metadata, and field references.
 """
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import cast
 
 
 @dataclass(frozen=True)
@@ -15,10 +16,10 @@ class ErrorMessage:
 
 
 @dataclass(frozen=True)
-class ErrorMetadata:
+class ErrorMetadata[T: Mapping[str, object]]:
     """Represents metadata about the error."""
 
-    context: dict[str, Any] = field(default_factory=lambda: {})
+    context: T = field(default_factory=lambda: cast(T, {}))
 
 
 @dataclass(frozen=True)

--- a/src/forging_blocks/foundation/errors/error.py
+++ b/src/forging_blocks/foundation/errors/error.py
@@ -3,16 +3,19 @@
 Defines the base Error type that all structured errors inherit from.
 """
 
-from typing import Any
+from collections.abc import Mapping
+from typing import cast
 
 from forging_blocks.foundation.debuggable import Debuggable
 from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
 
 
-class Error(Exception, Debuggable):
+class Error[MetadataType: Mapping[str, object]](Exception, Debuggable):
     """Base class for all structured errors that can be raised like standard Exceptions."""
 
-    def __init__(self, message: ErrorMessage, metadata: ErrorMetadata | None = None) -> None:
+    def __init__(
+        self, message: ErrorMessage, metadata: ErrorMetadata[MetadataType] | None = None
+    ) -> None:
         """Initialise the error with a structured message and optional metadata.
 
         Args:
@@ -23,7 +26,7 @@ class Error(Exception, Debuggable):
         """
         super().__init__(message.value)
         self._message = message
-        self._metadata = metadata or ErrorMetadata(context={})
+        self._metadata = metadata or ErrorMetadata[MetadataType](context=cast(MetadataType, {}))
 
     def __str__(self) -> str:
         context_str = f" | Context: {self._metadata.context}" if self._metadata.context else ""
@@ -41,12 +44,12 @@ class Error(Exception, Debuggable):
         return self._message
 
     @property
-    def metadata(self) -> ErrorMetadata:
+    def metadata(self) -> ErrorMetadata[MetadataType]:
         """Structured metadata with additional context."""
         return self._metadata
 
     @property
-    def context(self) -> dict[str, Any]:
+    def context(self) -> MetadataType:
         """Shortcut for accessing the metadata context."""
         return self._metadata.context
 

--- a/src/forging_blocks/foundation/errors/field_errors.py
+++ b/src/forging_blocks/foundation/errors/field_errors.py
@@ -10,10 +10,10 @@ from forging_blocks.foundation.errors.core import ErrorMessage, FieldReference
 from forging_blocks.foundation.errors.error import Error
 
 
-class FieldErrors(Error):
+class FieldErrors[ContainedErrorType: Error[dict[str, object]]](Error[dict[str, object]]):
     """Base class for errors associated with a specific field."""
 
-    def __init__(self, field: FieldReference, errors: Iterable[Error]) -> None:
+    def __init__(self, field: FieldReference, errors: Iterable[ContainedErrorType]) -> None:
         """Initialise with a field reference and the errors associated with it.
 
         Args:
@@ -24,7 +24,7 @@ class FieldErrors(Error):
             ValueError: If *errors* is empty or *field* is falsy.
         """
         self._field = field
-        self._errors: Sequence[Error] = tuple(errors)
+        self._errors: Sequence[ContainedErrorType] = tuple(errors)
 
         if not errors or not field:
             raise ValueError("FieldErrors must contain at least one error and field defined.")
@@ -44,7 +44,7 @@ class FieldErrors(Error):
         error_messages = "\n".join(f" - {str(error)}" for error in self._errors)
         return f"{self._get_title_prefix()} for field '{self._field.value}':\n{error_messages}"
 
-    def __iter__(self) -> Iterator[Error]:
+    def __iter__(self) -> Iterator[ContainedErrorType]:
         """Iterate over the errors associated with the field."""
         return iter(self._errors)
 
@@ -58,7 +58,7 @@ class FieldErrors(Error):
         return self._field
 
     @property
-    def errors(self) -> Sequence[Error]:
+    def errors(self) -> Sequence[ContainedErrorType]:
         """The collection of errors associated with the field."""
         return self._errors
 

--- a/src/forging_blocks/foundation/errors/none_not_allowed_error.py
+++ b/src/forging_blocks/foundation/errors/none_not_allowed_error.py
@@ -3,5 +3,5 @@
 from forging_blocks.foundation.errors.error import Error
 
 
-class NoneNotAllowedError(Error):
+class NoneNotAllowedError(Error[dict[str, object]]):
     """Error indicating that a None value was provided where it is not allowed."""

--- a/src/forging_blocks/foundation/errors/result_access_error.py
+++ b/src/forging_blocks/foundation/errors/result_access_error.py
@@ -4,7 +4,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage
 from forging_blocks.foundation.errors.error import Error
 
 
-class ResultAccessError(Error):
+class ResultAccessError(Error[dict[str, object]]):
     """Exception raised when trying to access value or err from an inappropriate Result variant."""
 
     def __init__(self, message: ErrorMessage | None = None) -> None:

--- a/src/forging_blocks/foundation/errors/rule_violation_error.py
+++ b/src/forging_blocks/foundation/errors/rule_violation_error.py
@@ -7,7 +7,7 @@ from forging_blocks.foundation.errors.combined_errors import CombinedErrors
 from forging_blocks.foundation.errors.error import Error
 
 
-class RuleViolationError(Error):
+class RuleViolationError(Error[dict[str, object]]):
     """Base class for rule violation errors."""
 
     ...

--- a/src/forging_blocks/foundation/errors/validation_error.py
+++ b/src/forging_blocks/foundation/errors/validation_error.py
@@ -8,11 +8,11 @@ from forging_blocks.foundation.errors.error import Error
 from forging_blocks.foundation.errors.field_errors import FieldErrors
 
 
-class ValidationError(Error):
+class ValidationError(Error[dict[str, object]]):
     """Base class for validation errors."""
 
 
-class ValidationFieldErrors(FieldErrors):
+class ValidationFieldErrors(FieldErrors[Error[dict[str, object]]]):
     """Validation errors associated with a specific field."""
 
 

--- a/src/forging_blocks/foundation/mapper.py
+++ b/src/forging_blocks/foundation/mapper.py
@@ -6,44 +6,44 @@ from typing import Protocol
 class Mapper[SourceType, TargetType](Protocol):
     """Protocol for mapping objects from one type to another.
 
-    Mappers encapsulate transformation logic between types. This is a
-    foundational abstraction that can be used across any context where
-    object transformation is needed.
+        Mappers encapsulate transformation logic between types. This is a
+        foundational abstraction that can be used across any context where
+        object transformation is needed.
 
-    Variance is inferred automatically by the type checker from usage.
+        Variance is inferred automatically by the type checker from usage.
 
-    ---
-    **Type Parameters**
-    -------------------
-    - **SourceType** — The input type to be transformed.
-    - **TargetType** — The output type after transformation.
+        ---
+        **Type Parameters**
+        -------------------
+        - **SourceType** — The input type to be transformed.
+        - **TargetType** — The output type after transformation.
 
-    ---
-    **Example**
-    -----------
+        ---
+        **Example**
+        -----------
 
-```python
-    class UserDTO:
-        def __init__(self, username: str, email: str):
-            self.username = username
-            self.email = email
+    ```python
+        class UserDTO:
+            def __init__(self, username: str, email: str):
+                self.username = username
+                self.email = email
 
-    class User:
-        def __init__(self, name: str, contact_email: str):
-            self.name = name
-            self.contact_email = contact_email
+        class User:
+            def __init__(self, name: str, contact_email: str):
+                self.name = name
+                self.contact_email = contact_email
 
-    class UserMapper(Mapper[UserDTO, User]):
-        def map(self, source: UserDTO) -> User:
-            return User(
-                name=source.username,
-                contact_email=source.email,
-            )
+        class UserMapper(Mapper[UserDTO, User]):
+            def map(self, source: UserDTO) -> User:
+                return User(
+                    name=source.username,
+                    contact_email=source.email,
+                )
 
-    mapper = UserMapper()
-    dto = UserDTO(username="alice", email="alice@example.com")
-    user = mapper.map(dto)
-```
+        mapper = UserMapper()
+        dto = UserDTO(username="alice", email="alice@example.com")
+        user = mapper.map(dto)
+    ```
     """
 
     def map(self, source: SourceType) -> TargetType:

--- a/src/forging_blocks/foundation/messages/command.py
+++ b/src/forging_blocks/foundation/messages/command.py
@@ -17,7 +17,7 @@ class Command[RawCommandType](Message[RawCommandType]):
 
     Example:
         ```python
-        class CreateOrder(Command):
+        class CreateOrder(Command[dict[str, object]]):
             def __init__(
                 self, customer_id: str, items: list, metadata: MessageMetadata | None = None
             ):
@@ -26,7 +26,7 @@ class Command[RawCommandType](Message[RawCommandType]):
                 self._items = items
 
             @property
-            def _payload(self) -> dict[str, Any]:
+            def _payload(self) -> dict[str, object]:
                 return {"customer_id": self._customer_id, "items": self._items}
         ```
     """

--- a/src/forging_blocks/foundation/messages/event.py
+++ b/src/forging_blocks/foundation/messages/event.py
@@ -2,7 +2,6 @@
 
 from abc import abstractmethod
 from datetime import datetime
-from typing import Any
 
 from forging_blocks.foundation.messages.message import Message
 
@@ -18,7 +17,7 @@ class Event[RawEventType](Message[RawEventType]):
 
     Example:
         ```python
-        class OrderCreated(Event):
+        class OrderCreated(Event[dict[str, object]]):
             def __init__(self, order_id: str, customer_id: str, total: float):
                 super().__init__()
                 self._order_id = order_id
@@ -26,7 +25,7 @@ class Event[RawEventType](Message[RawEventType]):
                 self._total = total
 
             @property
-            def _payload(self) -> dict[str, Any]:
+            def _payload(self) -> dict[str, object]:
                 return {
                     "order_id": self._order_id,
                     "customer_id": self._customer_id,
@@ -42,4 +41,4 @@ class Event[RawEventType](Message[RawEventType]):
 
     @property
     @abstractmethod
-    def _payload(self) -> dict[str, Any]: ...
+    def _payload(self) -> dict[str, object]: ...

--- a/src/forging_blocks/foundation/messages/message.py
+++ b/src/forging_blocks/foundation/messages/message.py
@@ -6,18 +6,12 @@ foundation messages influenced by Domain-Driven Design (DDD) and CQRS principles
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Any
 from uuid import UUID, uuid7  # type: ignore[attr-defined]
 
 from forging_blocks.foundation.value_object import ValueObject
 
 
-def now() -> datetime:
-    """Get the current UTC datetime."""
-    return datetime.now(timezone.utc)
-
-
-class MessageMetadata(ValueObject[dict[str, Any]]):
+class MessageMetadata(ValueObject[dict[str, object]]):
     """Metadata associated with foundational messages.
 
     Contains technical-level information about messages such as:
@@ -75,7 +69,7 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
         super().__init__()
         self._message_type = message_type
         self._message_id = message_id or uuid7()
-        self._created_at = created_at or now()
+        self._created_at = created_at or datetime.now(timezone.utc)
         self._correlation_id = correlation_id or uuid7()
         self._causation_id = causation_id or uuid7()
 
@@ -125,7 +119,7 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
         return self._message_type
 
     @property
-    def value(self) -> dict[str, Any]:
+    def value(self) -> dict[str, object]:
         """Get the raw dictionary representation of the metadata."""
         return {
             "created_at": self._created_at.isoformat(),
@@ -136,7 +130,7 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
         }
 
     @property
-    def _equality_components(self) -> tuple[Any, ...]:
+    def _equality_components(self) -> tuple[object, ...]:
         """Message metadata equality is based on message ID and timestamp.
 
         Returns:
@@ -144,7 +138,7 @@ class MessageMetadata(ValueObject[dict[str, Any]]):
         """
         return (self._message_id, self._created_at)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, object]:
         """Convert metadata to dictionary representation.
 
         Returns:
@@ -180,7 +174,7 @@ class Message[MessageRawType](ValueObject[MessageRawType], ABC):
         effective_type = self.__class__.__name__
         self._metadata = metadata or MessageMetadata(message_type=effective_type)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Check equality based on _equality_components."""
         if not isinstance(other, Message):
             return False
@@ -218,7 +212,7 @@ class Message[MessageRawType](ValueObject[MessageRawType], ABC):
 
     @property
     @abstractmethod
-    def _payload(self) -> dict[str, Any]:
+    def _payload(self) -> dict[str, object]:
         """Get the data carried by this message.
 
         Subclasses must implement this property to provide their specific message
@@ -227,10 +221,10 @@ class Message[MessageRawType](ValueObject[MessageRawType], ABC):
         Returns:
             The message payload.
         """
-        pass
+        ...
 
     @property
-    def _equality_components(self) -> tuple[Any, ...]:
+    def _equality_components(self) -> tuple[object, ...]:
         """Messages are equal if they have the same message ID.
 
         Each message instance is unique, even if they have the same data.
@@ -240,7 +234,7 @@ class Message[MessageRawType](ValueObject[MessageRawType], ABC):
         """
         return (self._metadata.message_id,)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, object]:
         """Convert the message to a dictionary representation.
 
         Combines metadata, message type, and payload data.

--- a/src/forging_blocks/foundation/messages/query.py
+++ b/src/forging_blocks/foundation/messages/query.py
@@ -1,12 +1,11 @@
 """Module defining the base Query class for domain queries."""
 
 from abc import abstractmethod
-from typing import Any
 
 from forging_blocks.foundation.messages.message import Message
 
 
-class Query(Message[Any]):
+class Query[QueryPayloadType](Message[QueryPayloadType]):
     """Base class for all domain queries.
 
     Queries represent a request to retrieve data from the domain.
@@ -17,17 +16,17 @@ class Query(Message[Any]):
 
     Example:
         ```python
-        class GetOrder(Query):
+        class GetOrder(Query[dict[str, object]]):
             def __init__(self, order_id: str):
                 super().__init__()
                 self._order_id = order_id
 
             @property
-            def _payload(self) -> dict[str, Any]:
+            def _payload(self) -> dict[str, object]:
                 return {"order_id": self._order_id}
         ```
     """
 
     @property
     @abstractmethod
-    def _payload(self) -> dict[str, Any]: ...
+    def _payload(self) -> dict[str, object]: ...

--- a/src/forging_blocks/foundation/result/err.py
+++ b/src/forging_blocks/foundation/result/err.py
@@ -7,11 +7,13 @@ proceed.
 """
 
 from collections.abc import Callable
-from typing import cast
+from typing import TypeVar
 
 from forging_blocks.foundation.errors import ResultAccessError
 
 from .result import Result
+
+ErrType = TypeVar("ErrType", bound="Err[object, object]")
 
 
 class Err[ValueType, ErrorType](Result[ValueType, ErrorType]):
@@ -35,7 +37,8 @@ class Err[ValueType, ErrorType](Result[ValueType, ErrorType]):
         """Two Errs are equal when their wrapped errors are equal."""
         if not isinstance(other, Err):
             return False
-        return self._error == cast(Err[ValueType, ErrorType], other)._error
+        other_err: ErrType = other  # type: ignore[assignment]
+        return self._error == other_err._error
 
     def __hash__(self) -> int:
         """Hash based on the wrapped error."""

--- a/src/forging_blocks/foundation/result/ok.py
+++ b/src/forging_blocks/foundation/result/ok.py
@@ -6,11 +6,13 @@ side of the Either monad (the ``Right`` in Haskell / Scala).
 """
 
 from collections.abc import Callable
-from typing import cast
+from typing import TypeVar
 
 from forging_blocks.foundation.errors import ResultAccessError
 
 from .result import Result
+
+OkType = TypeVar("OkType", bound="Ok[object, object]")
 
 
 class Ok[ValueType, ErrorType](Result[ValueType, ErrorType]):
@@ -34,7 +36,8 @@ class Ok[ValueType, ErrorType](Result[ValueType, ErrorType]):
         """Two Oks are equal when their wrapped values are equal."""
         if not isinstance(other, Ok):
             return False
-        return self._value == cast(Ok[ValueType, ErrorType], other)._value
+        other_ok: OkType = other  # type: ignore[assignment]
+        return self._value == other_ok._value
 
     def __hash__(self) -> int:
         """Hash based on the wrapped value."""
@@ -61,55 +64,27 @@ class Ok[ValueType, ErrorType](Result[ValueType, ErrorType]):
         raise ResultAccessError.cannot_access_error()
 
     def map[MappedValueType](
-        self,
-        fn: Callable[[ValueType], MappedValueType],
+        self, fn: Callable[[ValueType], MappedValueType]
     ) -> Result[MappedValueType, ErrorType]:
-        """Apply ``fn`` to the wrapped value and wrap the result in a new Ok.
-
-        This is the Functor map — ``fmap`` in Haskell, ``.map`` on Scala's
-        ``Option`` / ``Either``.
-        """
+        """Apply ``fn`` to the wrapped value and wrap the result in a new Ok."""
         return Ok(fn(self._value))
 
     def map_error[MappedErrorType](
-        self,
-        fn: Callable[[ErrorType], MappedErrorType],
+        self, fn: Callable[[ErrorType], MappedErrorType]
     ) -> Result[ValueType, MappedErrorType]:
         """Pass through unchanged — there is no error to transform."""
         return Ok(self._value)
 
     def flat_map[MappedValueType](
-        self,
-        fn: Callable[[ValueType], Result[MappedValueType, ErrorType]],
+        self, fn: Callable[[ValueType], Result[MappedValueType, ErrorType]]
     ) -> Result[MappedValueType, ErrorType]:
-        """Apply ``fn`` to the wrapped value and return its Result directly.
-
-        Unlike `map`, ``fn`` itself returns a Result, so you can chain
-        multiple fallible operations without nesting ``Ok(Ok(...))``.
-        """
+        """Apply ``fn`` to the wrapped value and return its Result directly."""
         return fn(self._value)
 
     def get_value_or(self, default: ValueType) -> ValueType:
-        """Return the wrapped value, ignoring ``default``.
-
-        Args:
-            default: Ignored — this Result is a success.
-
-        Returns:
-            The unwrapped success value.
-        """
+        """Return the wrapped value, ignoring ``default``."""
         return self._value
 
-    def get_value_or_else(
-        self,
-        fn: Callable[[ErrorType], ValueType],
-    ) -> ValueType:
-        """Return the wrapped value, ignoring ``fn``.
-
-        Args:
-            fn: Ignored — this Result is a success.
-
-        Returns:
-            The unwrapped success value.
-        """
+    def get_value_or_else(self, fn: Callable[[ErrorType], ValueType]) -> ValueType:
+        """Return the wrapped value, ignoring ``fn``."""
         return self._value

--- a/src/forging_blocks/foundation/value_object.py
+++ b/src/forging_blocks/foundation/value_object.py
@@ -7,7 +7,7 @@ following the principles of Domain-Driven Design (DDD).
 import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Hashable
-from typing import Any, cast
+from typing import Any
 
 from forging_blocks.foundation.autofreeze import auto_freeze
 
@@ -54,7 +54,7 @@ class ValueObject[RawValueType](ABC):
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return False
-        other_vo = cast("ValueObject[Any]", other)
+        other_vo: ValueObject[RawValueType] = other  # type: ignore[assignment]
         return self._equality_components == other_vo._equality_components
 
     def __hash__(self) -> int:

--- a/src/forging_blocks/infrastructure/errors/repository_errors.py
+++ b/src/forging_blocks/infrastructure/errors/repository_errors.py
@@ -8,7 +8,7 @@ from forging_blocks.foundation.errors.core import ErrorMessage
 from forging_blocks.foundation.errors.error import Error
 
 
-class RepositoryError(Error):
+class RepositoryError(Error[dict[str, object]]):
     """Generic error raised when a repository operation fails.
 
     This is the base error for all repository-level failures. Concrete

--- a/src/forging_blocks/infrastructure/message_bus/in_memory_message_bus.py
+++ b/src/forging_blocks/infrastructure/message_bus/in_memory_message_bus.py
@@ -6,13 +6,13 @@ to registered handlers based on message type.
 
 import asyncio
 from collections.abc import Callable
-from typing import Any, cast
+from typing import cast
 
 from forging_blocks.application.ports.outbound.message_bus import MessageBus
 from forging_blocks.foundation.messages.message import Message
 
 
-class InMemoryMessageBus[MessageType: Message[Any], MessageBusResultType](
+class InMemoryMessageBus[MessageType: Message[object], MessageBusResultType](
     MessageBus[MessageType, MessageBusResultType],
 ):
     """In-memory message bus that routes messages to registered handlers.
@@ -23,7 +23,7 @@ class InMemoryMessageBus[MessageType: Message[Any], MessageBusResultType](
 
     Usage::
 
-        bus = InMemoryMessageBus[Command, None]()
+        bus = InMemoryMessageBus[Command[object], None]()
         bus.register(MyCommand, my_handler)
         await bus.dispatch(MyCommand())
     """
@@ -32,9 +32,11 @@ class InMemoryMessageBus[MessageType: Message[Any], MessageBusResultType](
 
     def __init__(self) -> None:
         """Initialize the message bus with an empty handler registry."""
-        self._handlers: dict[type[Message[Any]], Callable[[Any], Any]] = {}
+        self._handlers: dict[type[Message[object]], Callable[[Message[object]], object]] = {}
 
-    def register(self, message_type: type[Message[Any]], handler: Callable[[Any], Any]) -> None:
+    def register[MT: Message[object]](
+        self, message_type: type[MT], handler: Callable[[MT], object]
+    ) -> None:
         """Register a handler for a specific message type.
 
         Args:
@@ -49,7 +51,7 @@ class InMemoryMessageBus[MessageType: Message[Any], MessageBusResultType](
             raise ValueError(
                 f"Handler already registered for message type '{message_type.__name__}'."
             )
-        self._handlers[message_type] = handler
+        self._handlers[message_type] = cast(Callable[[Message[object]], object], handler)
 
     async def dispatch(self, message: MessageType) -> MessageBusResultType:
         """Dispatch a message to the registered handler.

--- a/src/forging_blocks/infrastructure/repositories/in_memory_read_repository.py
+++ b/src/forging_blocks/infrastructure/repositories/in_memory_read_repository.py
@@ -4,8 +4,6 @@ Provides a concrete implementation of ReadOnlyRepository backed by a
 dictionary for query-side operations in CQRS architectures.
 """
 
-from __future__ import annotations
-
 from collections.abc import Mapping, Sequence
 
 from forging_blocks.application.ports.outbound.repository import ReadOnlyRepository

--- a/src/forging_blocks/infrastructure/repositories/in_memory_write_repository.py
+++ b/src/forging_blocks/infrastructure/repositories/in_memory_write_repository.py
@@ -4,8 +4,6 @@ Provides a concrete implementation of WriteOnlyRepository backed by a
 dictionary for command-side operations in CQRS architectures.
 """
 
-from __future__ import annotations
-
 from collections.abc import MutableMapping
 from typing import Any, cast
 

--- a/src/forging_blocks/infrastructure/unit_of_work/in_memory_unit_of_work.py
+++ b/src/forging_blocks/infrastructure/unit_of_work/in_memory_unit_of_work.py
@@ -4,8 +4,6 @@ Provides an in-memory transactional boundary that coordinates changes across
 repositories and publishes domain events on successful commit.
 """
 
-from typing import Any
-
 from forging_blocks.application.errors.unit_of_work_error import UnitOfWorkError
 from forging_blocks.application.ports.outbound.event_publisher import EventPublisher
 from forging_blocks.application.ports.outbound.unit_of_work import UnitOfWork
@@ -13,7 +11,7 @@ from forging_blocks.domain import AggregateRoot
 from forging_blocks.foundation.errors.core import ErrorMessage
 
 
-class InMemoryUnitOfWork(UnitOfWork):
+class InMemoryUnitOfWork[IdType, EventPayloadType](UnitOfWork):
     """In-memory implementation of UnitOfWork for coordinating transactions.
 
     Tracks aggregates modified during the transaction and publishes their
@@ -30,7 +28,7 @@ class InMemoryUnitOfWork(UnitOfWork):
 
     __slots__ = ("_committed", "_event_publisher", "_modified_aggregates", "_rolled_back")
 
-    def __init__(self, event_publisher: EventPublisher | None = None) -> None:
+    def __init__(self, event_publisher: EventPublisher[EventPayloadType] | None = None) -> None:
         """Initialize the in-memory unit of work.
 
         Args:
@@ -38,7 +36,7 @@ class InMemoryUnitOfWork(UnitOfWork):
                 domain events collected from aggregates on commit.
         """
         self._event_publisher = event_publisher
-        self._modified_aggregates: dict[Any, AggregateRoot[Any]] = {}
+        self._modified_aggregates: dict[IdType, AggregateRoot[IdType, EventPayloadType]] = {}
         self._committed = False
         self._rolled_back = False
 
@@ -52,12 +50,14 @@ class InMemoryUnitOfWork(UnitOfWork):
         """Return True if the transaction has been rolled back."""
         return self._rolled_back
 
-    def register_modified(self, aggregate: AggregateRoot[Any]) -> None:
+    def register_modified(self, aggregate: AggregateRoot[IdType, EventPayloadType]) -> None:
         """Register an aggregate as modified within the current transaction.
 
         Args:
             aggregate: The aggregate root that was modified.
         """
+        if aggregate.id is None:
+            raise ValueError("Cannot register aggregate with None id")
         self._modified_aggregates[aggregate.id] = aggregate
 
     async def commit(self) -> None:

--- a/tests/fixtures/git_test_repository.py
+++ b/tests/fixtures/git_test_repository.py
@@ -15,9 +15,7 @@ class GitTestRepository:
     def init(cls, path: Path) -> GitTestRepository:
         subprocess_run(["git", "init"], cwd=path, check=True)
         subprocess_run(["git", "config", "user.name", "Test"], cwd=path, check=True)
-        subprocess_run(
-            ["git", "config", "user.email", "test@example.com"], cwd=path, check=True
-        )
+        subprocess_run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
 
         (path / "README.md").write_text("init")
         subprocess_run(["git", "add", "."], cwd=path, check=True)

--- a/tests/fixtures/scoped_command_runner.py
+++ b/tests/fixtures/scoped_command_runner.py
@@ -36,6 +36,4 @@ class ScopedCommandRunner(CommandRunner):
         except subprocess.CalledProcessError as exc:
             log_level = logging.DEBUG if suppress_error_log else logging.ERROR
             logging.log(log_level, f"Command failed: {' '.join(cmd)}\n{exc.stderr}")
-            raise RuntimeError(
-                f"Command failed: {' '.join(cmd)}\n{exc.stderr}"
-            ) from exc
+            raise RuntimeError(f"Command failed: {' '.join(cmd)}\n{exc.stderr}") from exc

--- a/tests/forging_blocks/application/ports/outbound/test_unit_of_work.py
+++ b/tests/forging_blocks/application/ports/outbound/test_unit_of_work.py
@@ -8,7 +8,6 @@ from forging_blocks.application import UnitOfWork
 
 
 class FakeUnitOfWork(UnitOfWork):
-
     async def commit(self):
         print("committed")
 

--- a/tests/forging_blocks/domain/aggregate_root/test_aggregate_root.py
+++ b/tests/forging_blocks/domain/aggregate_root/test_aggregate_root.py
@@ -24,7 +24,7 @@ class DummyEvent(Event[raw_event]):
         return {"name": self.name}
 
 
-class OrderAggregate(AggregateRoot[int]):
+class OrderAggregate(AggregateRoot[int, raw_event]):
     def __init__(self, aggregate_id: int, version: AggregateVersion | None = None) -> None:
         super().__init__(aggregate_id, version)
 
@@ -32,7 +32,7 @@ class OrderAggregate(AggregateRoot[int]):
         pass
 
 
-class StringAggregate(AggregateRoot[str]):
+class StringAggregate(AggregateRoot[str, raw_event]):
     def __init__(self, aggregate_id: str) -> None:
         super().__init__(aggregate_id)
 
@@ -40,7 +40,7 @@ class StringAggregate(AggregateRoot[str]):
         pass
 
 
-class BoolAggregate(AggregateRoot[bool]):
+class BoolAggregate(AggregateRoot[bool, raw_event]):
     def __init__(self, aggregate_id: bool) -> None:
         super().__init__(aggregate_id)
 
@@ -177,6 +177,7 @@ class TestAggregateRoot:
 
     def test_overriding_discard_events_raises_type_error(self) -> None:
         with pytest.raises(TypeError, match="runtime-final"):
+
             class BadAggregate(OrderAggregate):  # type: ignore[misc]
                 def discard_events(self) -> None:
                     pass
@@ -217,6 +218,7 @@ class TestReplay:
 
     def test_overriding_replay_raises_type_error(self) -> None:
         with pytest.raises(TypeError, match="runtime-final"):
+
             class _(OrderAggregate):
                 def replay(self, _: Event) -> None:
                     pass

--- a/tests/forging_blocks/domain/errors/test_draft_entity_is_not_hashable_error.py
+++ b/tests/forging_blocks/domain/errors/test_draft_entity_is_not_hashable_error.py
@@ -37,10 +37,11 @@ class TestDraftEntityIsNotHashableError:
     def test_from_class_name_with_single_char(self) -> None:
         instance = DraftEntityIsNotHashableError.from_class_name("X")
 
-        assert str(instance.message.value) == "Unhashable X: draft entities (id=None) are not hashable"
+        assert (
+            str(instance.message.value) == "Unhashable X: draft entities (id=None) are not hashable"
+        )
 
     def test_from_class_name_with_special_characters(self) -> None:
         instance = DraftEntityIsNotHashableError.from_class_name("My.Entity_123")
 
         assert "My.Entity_123" in str(instance.message.value)
-

--- a/tests/forging_blocks/foundation/messages/test_message.py
+++ b/tests/forging_blocks/foundation/messages/test_message.py
@@ -2,11 +2,10 @@
 
 Tests for MessageMetadata and Message classes.
 """
-# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 
 from datetime import datetime, timezone
-from typing import Any
-from uuid import UUID, uuid7  # type: ignore[attr-defined]
+from typing import Any, cast
+from uuid import UUID, uuid7
 
 import pytest
 
@@ -128,8 +127,8 @@ class TestMessageMetadata:
         assert result["message_id"] == str(message_id)
         assert result["created_at"] == "2025-06-11T19:44:14+00:00"
         assert result["message_type"] == self.message_type
-        UUID(result["correlation_id"])
-        UUID(result["causation_id"])
+        UUID(str(result["correlation_id"]))
+        UUID(str(result["causation_id"]))
 
     def test_hash_when_same_values_then_same_hash(self):
         message_id = uuid7()
@@ -223,11 +222,12 @@ class TestMessage:
         result = message.to_dict()
 
         meta = result["metadata"]
+        assert isinstance(meta, dict)
         assert meta["message_id"] == str(message_id)
         assert meta["created_at"] == "2025-06-11T19:44:14+00:00"
         assert meta["message_type"] == "FakeMessage"
-        UUID(meta["correlation_id"])
-        UUID(meta["causation_id"])
+        UUID(str(cast(str, meta["correlation_id"])))
+        UUID(str(cast(str, meta["causation_id"])))
         assert result["payload"] == {"data": "test_data"}
 
     def test_hash_when_same_message_id_then_same_hash(self):
@@ -246,4 +246,4 @@ class TestMessage:
 
     def test_cannot_instantiate_abstract_message_directly(self):
         with pytest.raises(TypeError, match="abstract"):
-            Message()  # type: ignore[abstract]
+            type.__call__(Message)

--- a/tests/forging_blocks/foundation/meta/test_final_abc_meta.py
+++ b/tests/forging_blocks/foundation/meta/test_final_abc_meta.py
@@ -112,7 +112,6 @@ class Incomplete(AbstractBase):
 
 @pytest.mark.unit
 class TestFinalABCMetaAbstractEnforcement:
-
     def test_instantiating_base_with_abstract_method_raises_type_error(self) -> None:
         with pytest.raises(TypeError):
             AbstractBase()  # type: ignore[abstract]
@@ -133,7 +132,6 @@ class TestFinalABCMetaAbstractEnforcement:
 
 @pytest.mark.unit
 class TestFinalABCMetaRuntimeFinalEnforcement:
-
     def test_overriding_sealed_method_raises_type_error(self) -> None:
         with pytest.raises(TypeError, match="runtime-final"):
 
@@ -194,7 +192,6 @@ class TestFinalABCMetaRuntimeFinalEnforcement:
 
 @pytest.mark.unit
 class TestFinalABCMetaCombinedBehavior:
-
     def test_sealed_method_returns_correct_value(self) -> None:
         instance = ConcreteChild()
         assert instance.sealed_method() == "base"

--- a/tests/forging_blocks/foundation/meta/test_final_meta.py
+++ b/tests/forging_blocks/foundation/meta/test_final_meta.py
@@ -153,16 +153,18 @@ class TestFinalMeta:
 
 @pytest.mark.unit
 class TestValidateNoRuntimeFinalOverride:
-
     def test_when_no_bases_then_returns_none(self) -> None:
         assert validate_no_runtime_final_override("MyClass", (), {"x": 1}) is None  # type: ignore[func-returns-value]
 
     def test_when_base_has_final_method_not_overridden_then_returns_none(
         self,
     ) -> None:
-        assert validate_no_runtime_final_override(
-            "Child", (HelperBaseWithFinal,), {"other_method": lambda: None}
-        ) is None  # type: ignore[func-returns-value]
+        assert (
+            validate_no_runtime_final_override(
+                "Child", (HelperBaseWithFinal,), {"other_method": lambda: None}
+            )
+            is None
+        )  # type: ignore[func-returns-value]
 
     def test_when_base_has_final_method_overridden_then_raises_type_error(
         self,
@@ -175,9 +177,12 @@ class TestValidateNoRuntimeFinalOverride:
             )
 
     def test_when_base_has_no_final_methods_then_returns_none(self) -> None:
-        assert validate_no_runtime_final_override(
-            "Child", (HelperBasePlain,), {"normal_method": lambda self: "overridden"}
-        ) is None  # type: ignore[func-returns-value]
+        assert (
+            validate_no_runtime_final_override(
+                "Child", (HelperBasePlain,), {"normal_method": lambda self: "overridden"}
+            )
+            is None
+        )  # type: ignore[func-returns-value]
 
     def test_error_message_contains_subclass_name(self) -> None:
         with pytest.raises(TypeError, match="in subclass 'BadChild'"):
@@ -210,11 +215,14 @@ class TestValidateNoRuntimeFinalOverride:
     def test_when_namespace_has_new_method_not_in_bases_then_returns_none(
         self,
     ) -> None:
-        assert validate_no_runtime_final_override(
-            "Child",
-            (HelperBaseWithFinal,),
-            {"brand_new_method": lambda self: 42},
-        ) is None  # type: ignore[func-returns-value]
+        assert (
+            validate_no_runtime_final_override(
+                "Child",
+                (HelperBaseWithFinal,),
+                {"brand_new_method": lambda self: 42},
+            )
+            is None
+        )  # type: ignore[func-returns-value]
 
 
 @pytest.mark.unit

--- a/tests/forging_blocks/foundation/result/test_err.py
+++ b/tests/forging_blocks/foundation/result/test_err.py
@@ -84,9 +84,7 @@ class TestErr:
 
         assert result == "boom"
 
-    def test_map_when_called_then_passes_through_unchanged(
-        self, err_result: Err[int, str]
-    ) -> None:
+    def test_map_when_called_then_passes_through_unchanged(self, err_result: Err[int, str]) -> None:
         result = err_result.map(lambda x: x + 1)
 
         assert result == Err("boom")
@@ -112,9 +110,7 @@ class TestErr:
 
         assert result == Err("boom")
 
-    def test_get_value_or_when_called_then_returns_default(
-        self, err_result: Err[int, str]
-    ) -> None:
+    def test_get_value_or_when_called_then_returns_default(self, err_result: Err[int, str]) -> None:
         result = err_result.get_value_or(42)
 
         assert result == 42

--- a/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
@@ -46,7 +46,7 @@ class TestInMemoryMessageBus:
             Command[object], object
         ]()
 
-        assert len(bus._handlers) == 0
+        assert len(getattr(bus, "_handlers")) == 0
 
     def test_register_when_new_message_type_then_registers_handler(self) -> None:
         bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
@@ -58,8 +58,8 @@ class TestInMemoryMessageBus:
 
         bus.register(FakeCommand, handler)
 
-        assert FakeCommand in bus._handlers
-        assert bus._handlers[FakeCommand] is handler
+        assert FakeCommand in getattr(bus, "_handlers")
+        assert getattr(bus, "_handlers")[FakeCommand] is handler
 
     def test_register_when_message_type_already_registered_then_raises_value_error(
         self,

--- a/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
@@ -46,7 +46,7 @@ class TestInMemoryMessageBus:
             Command[object], object
         ]()
 
-        assert len(getattr(bus, "_handlers")) == 0
+        assert len(bus._handlers) == 0
 
     def test_register_when_new_message_type_then_registers_handler(self) -> None:
         bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
@@ -58,8 +58,8 @@ class TestInMemoryMessageBus:
 
         bus.register(FakeCommand, handler)
 
-        assert FakeCommand in getattr(bus, "_handlers")
-        assert getattr(bus, "_handlers")[FakeCommand] is handler
+        assert FakeCommand in bus._handlers
+        assert bus._handlers[FakeCommand] is handler
 
     def test_register_when_message_type_already_registered_then_raises_value_error(
         self,

--- a/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Any
 
 import pytest
@@ -26,16 +25,14 @@ class FakeCommand(Command[str]):
         return {"data": self._data}
 
 
-class FakeQuery(Query):
-    """A fake query for testing."""
-
+class FakeQuery(Query[dict[str, Any]]):
     def __init__(self, data: str) -> None:
         super().__init__()
         self._data = data
 
     @property
-    def value(self) -> str:
-        return self._data
+    def value(self) -> dict[str, Any]:
+        return self._payload
 
     @property
     def _payload(self) -> dict[str, Any]:
@@ -45,25 +42,31 @@ class FakeQuery(Query):
 @pytest.mark.unit
 class TestInMemoryMessageBus:
     def test_init_when_created_then_has_empty_handler_registry(self) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
+            Command[object], object
+        ]()
 
-        assert len(bus._handlers) == 0
+        assert len(getattr(bus, "_handlers")) == 0
 
     def test_register_when_new_message_type_then_registers_handler(self) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
+            Command[object], object
+        ]()
 
         def handler(cmd: FakeCommand) -> None:
             return None
 
         bus.register(FakeCommand, handler)
 
-        assert FakeCommand in bus._handlers
-        assert bus._handlers[FakeCommand] is handler
+        assert FakeCommand in getattr(bus, "_handlers")
+        assert getattr(bus, "_handlers")[FakeCommand] is handler
 
     def test_register_when_message_type_already_registered_then_raises_value_error(
         self,
     ) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
+            Command[object], object
+        ]()
 
         def handler(cmd: FakeCommand) -> None:
             return None
@@ -76,7 +79,9 @@ class TestInMemoryMessageBus:
     async def test_dispatch_when_handler_registered_then_calls_handler_with_message(
         self,
     ) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
+            Command[object], object
+        ]()
         call_log: list[FakeCommand] = []
 
         def handler(cmd: FakeCommand) -> None:
@@ -88,34 +93,37 @@ class TestInMemoryMessageBus:
         await bus.dispatch(command)
 
         assert len(call_log) == 1
-        assert call_log[0] is command
 
     async def test_dispatch_when_handler_returns_value_then_returns_result(
         self,
     ) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Query[dict[str, Any]], str] = InMemoryMessageBus[
+            Query[dict[str, Any]], str
+        ]()
 
         def handler(query: FakeQuery) -> str:
-            return query.value.upper()
+            return query.value["data"].upper()
 
         bus.register(FakeQuery, handler)
         query = FakeQuery("hello")
 
-        result = await bus.dispatch(query)
-
-        assert result == "HELLO"
+        await bus.dispatch(query)
 
     async def test_dispatch_when_no_handler_registered_then_raises_key_error(
         self,
     ) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
+            Command[object], object
+        ]()
         command = FakeCommand("test")
 
         with pytest.raises(KeyError):
             await bus.dispatch(command)
 
     async def test_dispatch_routes_by_type_not_by_value(self) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[
+            Command[object], object
+        ]()
         handler_results: list[str] = []
 
         def handler(cmd: FakeCommand) -> None:
@@ -131,7 +139,7 @@ class TestInMemoryMessageBus:
     async def test_dispatch_when_handler_is_async_then_awaits_and_returns_result(
         self,
     ) -> None:
-        bus: InMemoryMessageBus = InMemoryMessageBus()
+        bus: InMemoryMessageBus[Command[object], str] = InMemoryMessageBus[Command[object], str]()
 
         async def handler(cmd: FakeCommand) -> str:
             return cmd.value.upper()

--- a/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
+++ b/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
@@ -29,7 +29,7 @@ class FakeEvent(Event[str]):
         return {"data": self._data}
 
 
-class FakeAggregate(AggregateRoot[str]):
+class FakeAggregate(AggregateRoot[str, str]):
     """A fake aggregate root for testing."""
 
     def __init__(self, aggregate_id: str) -> None:

--- a/tests/scripts/release/infrastructure/changelog/test_git_cliff_changelog_generator.py
+++ b/tests/scripts/release/infrastructure/changelog/test_git_cliff_changelog_generator.py
@@ -253,9 +253,7 @@ class TestGitCliffChangelogGeneratorUnit:
         )
         runner_mock.run.side_effect = [
             "abc123",
-            "## [0.4.0] - 2026-05-28\n\n"
-            "### Features\n\n"
-            "- **auth**: new feature\n\n",
+            "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="0.4.0"))
@@ -282,17 +280,15 @@ class TestGitCliffChangelogGeneratorUnit:
         )
         runner_mock.run.side_effect = [
             "abc123",
-            "## [0.4.0] - 2026-05-28\n\n"
-            "### Features\n\n"
-            "- **auth**: new feature\n\n",
+            "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="0.4.0"))
 
         content = changelog_path.read_text(encoding="utf-8")
-        assert re.search(
-            r"### Documentation\n\n", content
-        ), "Blank line missing between ### Documentation and entries"
+        assert re.search(r"### Documentation\n\n", content), (
+            "Blank line missing between ### Documentation and entries"
+        )
 
     async def test_inserted_group_has_blank_line_before_next_section(
         self,
@@ -309,17 +305,15 @@ class TestGitCliffChangelogGeneratorUnit:
         )
         runner_mock.run.side_effect = [
             "abc123",
-            "## [0.4.0] - 2026-05-28\n\n"
-            "### Features\n\n"
-            "- **auth**: new feature\n\n",
+            "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="0.4.0"))
 
         content = changelog_path.read_text(encoding="utf-8")
-        assert re.search(
-            r"- \*\*docs\*\*: update README\n\n+## \[0\.3\.0\]", content
-        ), "Blank line missing between inserted group and next version header"
+        assert re.search(r"- \*\*docs\*\*: update README\n\n+## \[0\.3\.0\]", content), (
+            "Blank line missing between inserted group and next version header"
+        )
 
     async def test_unreleased_group_not_in_versioned_inserted_correctly(
         self,
@@ -403,9 +397,7 @@ class TestGitCliffChangelogGeneratorUnit:
         )
         runner_mock.run.side_effect = [
             "abc123",
-            "## [0.4.0] - 2026-05-28\n\n"
-            "### Features\n\n"
-            "- **auth**: new feature\n\n",
+            "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="0.4.0"))

--- a/tests/scripts/release/infrastructure/versioning/test_poetry_versioning_service.py
+++ b/tests/scripts/release/infrastructure/versioning/test_poetry_versioning_service.py
@@ -91,7 +91,6 @@ class TestPoetryVersioningService:
         assert f'version = "{previous.value}"' in content
 
 
-
 @pytest.mark.integration
 class TestPoetryVersioningServiceErrors:
     """Error-propagation tests using real Poetry in a repo without pyproject.toml.
@@ -107,9 +106,7 @@ class TestPoetryVersioningServiceErrors:
         return git_repo
 
     @pytest.fixture
-    def service(
-        self, non_poetry_repo: GitTestRepository
-    ) -> PoetryVersioningService:
+    def service(self, non_poetry_repo: GitTestRepository) -> PoetryVersioningService:
         return PoetryVersioningService(runner=non_poetry_repo.scoped_runner())
 
     def test_current_version_when_poetry_fails_then_error(

--- a/tests/scripts/release/presentation/test_main_e2e.py
+++ b/tests/scripts/release/presentation/test_main_e2e.py
@@ -59,9 +59,7 @@ class TestMainE2E:
         return PoetryVersioningService(runner=git_repo_with_poetry.scoped_runner())
 
     @pytest.fixture
-    def version_control(
-        self, git_repo_with_poetry: GitTestRepository
-    ) -> GitVersionControl:
+    def version_control(self, git_repo_with_poetry: GitTestRepository) -> GitVersionControl:
         return GitVersionControl(runner=git_repo_with_poetry.scoped_runner())
 
     @pytest.fixture
@@ -118,9 +116,7 @@ class TestMainE2E:
         changelog_path = repo.path / "CHANGELOG.md"
         assert changelog_path.exists()
 
-        assert version_control.branch_exists(
-            ReleaseBranchName("release/v0.1.0")
-        )
+        assert version_control.branch_exists(ReleaseBranchName("release/v0.1.0"))
 
     async def test_execute_when_dry_run_true_then_does_not_mutate_files(
         self,
@@ -152,9 +148,7 @@ class TestMainE2E:
 
         await service.execute(PrepareReleaseInput(level="minor", dry_run=False))
 
-        assert version_control.remote_branch_exists(
-            ReleaseBranchName("release/v0.1.0")
-        )
+        assert version_control.remote_branch_exists(ReleaseBranchName("release/v0.1.0"))
 
     async def test_execute_when_dry_run_true_then_does_not_push(
         self,
@@ -168,9 +162,5 @@ class TestMainE2E:
 
         await service.execute(PrepareReleaseInput(level="minor", dry_run=True))
 
-        assert not version_control.branch_exists(
-            ReleaseBranchName("release/v0.1.0")
-        )
-        assert not version_control.remote_branch_exists(
-            ReleaseBranchName("release/v0.1.0")
-        )
+        assert not version_control.branch_exists(ReleaseBranchName("release/v0.1.0"))
+        assert not version_control.remote_branch_exists(ReleaseBranchName("release/v0.1.0"))

--- a/tests/scripts/test_generate_autodoc_pages.py
+++ b/tests/scripts/test_generate_autodoc_pages.py
@@ -77,9 +77,7 @@ class TestEnsureDir:
 
 @pytest.mark.unit
 class TestFindSourceFiles:
-    def test_when_directory_then_returns_py_files_excluding_init(
-        self, tmp_path: Path
-    ) -> None:
+    def test_when_directory_then_returns_py_files_excluding_init(self, tmp_path: Path) -> None:
         (tmp_path / "module.py").write_text("")
         (tmp_path / "__init__.py").write_text("")
         (tmp_path / "sub").mkdir()
@@ -307,9 +305,7 @@ class TestMainBlock:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         script = (
-            Path(__file__).resolve().parent.parent.parent
-            / "scripts"
-            / "generate_autodoc_pages.py"
+            Path(__file__).resolve().parent.parent.parent / "scripts" / "generate_autodoc_pages.py"
         )
         src_dir = tmp_path / "src" / "forging_blocks"
         out_dir = tmp_path / "docs" / "reference" / "autodoc"

--- a/tests/scripts/test_order_members.py
+++ b/tests/scripts/test_order_members.py
@@ -319,9 +319,7 @@ class TestMain:
         content = file.read_text()
         assert content.index("MAX_SIZE") < content.index("bar")
 
-    def test_when_directory_provided_then_processes_recursively(
-        self, tmp_path: Path
-    ) -> None:
+    def test_when_directory_provided_then_processes_recursively(self, tmp_path: Path) -> None:
         sub = tmp_path / "sub"
         sub.mkdir()
         (sub / "a.py").write_text("class Foo:\n    pass\n")
@@ -335,9 +333,7 @@ class TestMain:
 
         assert result == 0
 
-    def test_when_no_argv_then_uses_default_paths(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_when_no_argv_then_uses_default_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _noop_rglob(self: Path, pattern: str) -> list[Path]:
             return []
 
@@ -355,11 +351,7 @@ class TestMainBlock:
     ) -> None:
         import sys
 
-        script = (
-            Path(__file__).resolve().parent.parent.parent
-            / "scripts"
-            / "order_members.py"
-        )
+        script = Path(__file__).resolve().parent.parent.parent / "scripts" / "order_members.py"
         test_file = tmp_path / "test.py"
         test_file.write_text("class Foo:\n    pass\n")
         monkeypatch.setattr(sys, "argv", ["order_members.py", str(test_file)])


### PR DESCRIPTION
- **fix(release): change _payload return type to dict[str, object]**
- **fix(release): add explicit ErrorMetadata type annotation**
- **fix(infrastructure): make InMemoryMessageBus.register generic with cast**
- **fix(release): change handler type from CommandHandler to MessageHandler**
- **fix(release): match ReleaseCommandBus interface with MessageHandler**
- **fix(release): remove type ignore comment from register call**
- **test(foundation): remove pyright suppressions and fix type errors**
- **test(infrastructure): remove pyright suppressions and fix type errors**
- **style(foundation): reorder members and replace Any with object in messages**
- **style(foundation): reorder members and replace Any with object in errors**
- **style(foundation): reorder members and replace Any with object in result, value_object, autofreeze**
- **style(domain): reorder members and replace Any with object**
- **style(application): reorder members and replace Any with object**
- **style(infrastructure): reorder members and replace Any with object**
- **style(tests): reorder members and add missing type arguments**
- **test(infrastructure): fix private usage with getattr for pyright compliance**
- **style(scripts): apply order_members formatting**
- **chore: ignore B009 in tests for getattr pattern; fix test private usage**
