### PR TITLE
fix: doc default shows 0.4.1 instead of dev

### DIFF
--- a/docs/redirect_template.html
+++ b/docs/redirect_template.html
@@ -108,7 +108,7 @@
         var linkEl = document.getElementById("redirect-link");
         if (linkEl) linkEl.href = serverDefault;
 
-        var versionsUrl = "{{ href }}versions.json";
+        var versionsUrl = "versions.json";
         var timer = null;
 
         function doRedirect(target) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,9 +179,9 @@ test = { env = { "RUN_GITHUB_CLI_TESTS" = "1", "RUN_E2E_TESTS" = "1" }, cmd = "p
 "docs:build" = { shell = "python scripts/generate_autodoc_pages.py && poetry run mkdocs build --strict && git show HEAD:mkdocs.yml > mkdocs.yml" }
 
 "docs:serve" = { shell = "python scripts/generate_autodoc_pages.py && poetry run mike serve" }
-"docs:deploy:dev" = { shell = "poetry run poe docs:generate && poetry run mike deploy --push --update-aliases dev latest && poetry run mike set-default --push dev" }
+"docs:deploy:dev" = { shell = "poetry run poe docs:generate && poetry run mike deploy --push dev && poetry run mike set-default --push dev" }
 
-"docs:deploy:release" = { shell = "poetry run poe docs:generate && poetry run mike deploy --push --update-aliases v$(poetry version -s) latest && poetry run mike set-default --push latest" }
+"docs:deploy:release" = { shell = "poetry run poe docs:generate && poetry run mike deploy --push --update-aliases v$(poetry version -s) latest" }
 
 "docs:versions" = { cmd = "poetry run mike list" }
 

--- a/scripts/deploy_versioned_docs.sh
+++ b/scripts/deploy_versioned_docs.sh
@@ -71,12 +71,7 @@ else
   else
     poetry run mike deploy --push --update-aliases $MIKE_OPTS "v$VERSION" latest "$VERSION"
   fi
-  echo "==> Setting default version to latest..."
-  if [[ -n "$DRY_RUN" ]]; then
-    poetry run mike set-default $MIKE_OPTS latest
-  else
-    poetry run mike set-default --push $MIKE_OPTS latest
-  fi
+  echo "==> NOTE: Default version remains unchanged (use 'dev' deploy to set default)."
 fi
 
 echo "==> Done. View deployed versions with: poetry run mike list"

--- a/scripts/generate_redirect_template.py
+++ b/scripts/generate_redirect_template.py
@@ -232,7 +232,7 @@ def generate_template(source_html: str, output_path: Path) -> None:
         var linkEl = document.getElementById("redirect-link");
         if (linkEl) linkEl.href = serverDefault;
 
-        var versionsUrl = "{{{{ href }}}}versions.json";
+        var versionsUrl = "versions.json";
         var timer = null;
 
         function doRedirect(target) {{

--- a/tests/scripts/test_generate_redirect_template.py
+++ b/tests/scripts/test_generate_redirect_template.py
@@ -293,7 +293,7 @@ class TestGenerateTemplate:
         generate_template(html, output)
 
         content = output.read_text(encoding="utf-8")
-        assert content.count("{{ href }}") >= 5
+        assert content.count("{{ href }}") >= 4
 
     def test_when_template_has_version_dropdown_scripts(self, tmp_path: Path) -> None:
         html = _build_page_html(_build_head_html())


### PR DESCRIPTION
## Problem

The deployed docs showed `v0.4.1` as the default version instead of `dev`. Two root causes:

1. **Stale `dev/versions.json`**: The redirect template fetched `versions.json` from the default version's subdirectory (`dev/versions.json`), which was a snapshot from when `v0.4.1` was latest — with `v0.4.1` marked `is_default: true`.

2. **Release deploys changed the default**: `deploy_versioned_docs.sh` and `pyproject.toml` called `mike set-default latest` after deploying a release, overwriting the `dev` default.

## Fixes

- **Redirect template**: Fetch `versions.json` from the site root instead of `{{ href }}versions.json` — the root copy is always up-to-date
- **deploy_versioned_docs.sh**: Release deploys no longer change the default version
- **pyproject.toml**: `docs:deploy:release` no longer calls `set-default latest`; `docs:deploy:dev` no longer aliases `dev` as `latest`
- **Tests**: Updated `{{ href }}` placeholder count assertion

## Live gh-pages fixes (already applied)

- Moved `latest` alias from `v0.4.2` to `v0.4.3` in root `versions.json`
- Deleted stale `dev/versions.json`