### PR TITLE
feat/application services and domain validators

### DIFF
--- a/docs/reference/domain.md
+++ b/docs/reference/domain.md
@@ -36,6 +36,8 @@ The Domain block is the innermost ring. It imports nothing from outer layers. Wh
 - **[Aggregate Root](domain/aggregates.md)** — Consistency boundary; controls mutation and invariants
 - **[Specification](domain/specifications.md)** — Composable predicates for business rules, querying, and validation
 - **[Domain Errors](domain/errors.md)** — Invalid states and rule violations in domain terms
+- **[Validators](domain/validators.md)** — Concrete validation rules (RequiredValidator, EmailValidator, LengthValidator, RangeValidator)
+- **[Permissions](domain/permissions.md)** — Composable permission checkers (RoleBased, ResourceBased, Composite)
 
 ---
 ## What it does not do

--- a/docs/reference/domain/permissions.md
+++ b/docs/reference/domain/permissions.md
@@ -1,0 +1,57 @@
+# Permissions
+
+Composable permission-checking strategies for authorization decisions. Each checker evaluates an `AuthorizationContext` against a specific `Permission` and returns `True` when granted.
+
+## PermissionChecker
+
+`PermissionChecker` is a `Protocol` that any permission-checking implementation must satisfy.
+
+```python
+class PermissionChecker(Protocol):
+    async def check(self, context: AuthorizationContext, permission: Permission) -> bool:
+        ...
+```
+
+Implementations may be synchronous or asynchronous — callers always `await` the result.
+
+## RoleBasedPermissionChecker
+
+Grants permissions based on a static mapping of roles to allowed permissions. Looks up the user's roles in the `AuthorizationContext` and checks whether any assigned role includes the requested permission.
+
+```python
+checker = RoleBasedPermissionChecker({
+    "admin": [Permission.READ, Permission.WRITE, Permission.DELETE, Permission.ADMIN],
+    "editor": [Permission.READ, Permission.WRITE],
+})
+```
+
+## ResourcePermissionChecker
+
+Grants permissions based on a static mapping of resource types to allowed permissions. Inspects `AuthorizationContext.resource_type` and checks whether the targeted resource type permits the requested permission.
+
+```python
+checker = ResourcePermissionChecker({
+    "document": [Permission.READ, Permission.WRITE],
+    "image": [Permission.READ],
+})
+```
+
+## CompositePermissionChecker
+
+Combines multiple `PermissionChecker` instances with OR logic. A check passes as soon as **any** inner checker approves. Returns `True` immediately on the first success; otherwise `False` after all checkers have been consulted.
+
+```python
+checker = CompositePermissionChecker([
+    RoleBasedPermissionChecker({"admin": [Permission.READ]}),
+    ResourcePermissionChecker({"document": [Permission.READ]}),
+])
+```
+
+## When to use
+
+Use `RoleBasedPermissionChecker` for role-driven authorization (RBAC). Use `ResourcePermissionChecker` for resource-level access control. Combine them with `CompositePermissionChecker` when authorization depends on multiple factors — an admin role OR ownership of a document, for example.
+
+All checkers operate on the foundation `AuthorizationContext` and `Permission` types, keeping the domain free of infrastructure concerns.
+
+!!! note "Related"
+    See [Foundation Context](../foundation/context.md) for `AuthorizationContext` and `Permission`, and [Foundation Errors](../foundation/errors.md) for error types.

--- a/docs/reference/domain/permissions.md
+++ b/docs/reference/domain/permissions.md
@@ -12,7 +12,7 @@ class PermissionChecker(Protocol):
         ...
 ```
 
-Implementations may be synchronous or asynchronous — callers always `await` the result.
+Implementations may internally use synchronous logic, but must expose an `async def check(...)` method — callers always `await` the result.
 
 ## RoleBasedPermissionChecker
 

--- a/docs/reference/domain/validators.md
+++ b/docs/reference/domain/validators.md
@@ -1,0 +1,58 @@
+# Validators
+
+Concrete `ValidationRule` implementations for common input constraints. Each validator is a stateless, reusable rule that returns `RuleViolationError` instances when the input fails its constraint.
+
+## RequiredValidator
+
+Fails when the value is `None` or an empty string. Useful for mandatory form fields, API parameters, and command properties.
+
+```python
+RequiredValidator("username").validate(None)     # -> [RuleViolationError]
+RequiredValidator("username").validate("Alice")  # -> []
+```
+
+## EmailValidator
+
+Validates that a string value matches a basic RFC-compatible email pattern. Suitable for client-side and API-level validation — does not check deliverability.
+
+```python
+EmailValidator("email").validate("user@example.com")  # -> []
+EmailValidator("email").validate("not-an-email")      # -> [RuleViolationError]
+```
+
+## LengthValidator
+
+Validates that a string's length falls within a `[minimum_length, maximum_length]` range. Both bounds are inclusive and optional — omit a bound to leave it unconstrained.
+
+```python
+LengthValidator("password", minimum_length=8, maximum_length=128).validate("short")  # -> [RuleViolationError]
+LengthValidator("password", minimum_length=8).validate("0" * 10)                      # -> []
+```
+
+## RangeValidator
+
+Validates that a numeric value (integer or float) falls within a `[minimum_value, maximum_value]` range. Both bounds are inclusive and optional.
+
+```python
+RangeValidator("age", minimum_value=0, maximum_value=150).validate(-5)  # -> [RuleViolationError]
+RangeValidator("age", minimum_value=0).validate(30)                     # -> []
+```
+
+## CompositeValidationRule
+
+Combines multiple validators into a single rule. Evaluates every rule and returns all errors — there is no short-circuit. Every violation is reported.
+
+```python
+composite = CompositeValidationRule([
+    RequiredValidator("email"),
+    EmailValidator("email"),
+])
+composite.validate("bad")  # -> [RuleViolationError for invalid_email]
+```
+
+## When to use
+
+Use individual validators for single-field checks in commands, queries, and API input. Compose them with `CompositeValidationRule` when multiple constraints apply to the same field or when several fields must be validated together. All validators use the foundation `RuleViolationError` type with `ErrorMetadata` carrying field and error-code context.
+
+!!! note "Related"
+    See [Foundation Rules](../foundation/rules.md) for the `ValidationRule` base class and [Foundation Errors](../foundation/errors.md) for `RuleViolationError`.

--- a/docs/reference/foundation.md
+++ b/docs/reference/foundation.md
@@ -44,6 +44,8 @@ The Foundation block is pure Python — standard library only. It introduces no 
 - **[Mappers](foundation/mappers.md)** — Explicit transformations between types
 - **[Identified](foundation/identified.md)** — Protocol for objects carrying an identifier
 - **[Meta Utilities](foundation/meta.md)** — Runtime enforcement (final, sealed, abstract)
+- **[Context](foundation/context.md)** — Immutable context objects (ServiceContext, AuthorizationContext, TransactionContext)
+- **[Rules](foundation/rules.md)** — Composable validation rules (ValidationRule)
 
 ---
 ## What it does not do

--- a/docs/reference/foundation/context.md
+++ b/docs/reference/foundation/context.md
@@ -1,0 +1,53 @@
+# Context
+
+Context objects carry metadata through application boundaries — tracing identifiers, user identity, permissions, and transaction state.
+
+## AuthorizationContext
+
+`AuthorizationContext` bundles the information needed for a single authorization decision: the requesting user, their roles, the target resource, and the action being performed.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `user_id` | `str` | Unique identifier of the user requesting access |
+| `roles` | `list[str] \| None` | Roles assigned to the user |
+| `resource_id` | `str \| None` | Identifier of the resource being accessed |
+| `resource_type` | `str \| None` | Discriminator for the resource kind |
+| `action` | `str \| None` | Name of the action being performed |
+| `metadata` | `dict[str, Any] \| None` | Arbitrary key-value pairs for cross-cutting concerns |
+
+## ServiceContext
+
+`ServiceContext` carries cross-cutting metadata through every application-service call: a correlation identifier for tracing, the authenticated user, and their permissions.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `correlation_id` | `UUID` | Unique identifier tracing the entire request lifecycle (auto-generated) |
+| `user_id` | `str \| None` | Identifier of the authenticated user |
+| `permissions` | `list[str]` | Permissions held by the current user |
+| `metadata` | `dict[str, Any]` | Arbitrary key-value pairs for tracing and feature flags |
+
+## TransactionContext
+
+`TransactionContext` carries metadata for a single transactional boundary: a unique transaction identifier, the timestamp it began, and the requested isolation level.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transaction_id` | `UUID` | Unique identifier for the transaction (auto-generated) |
+| `started_at` | `datetime` | UTC timestamp when the transaction began |
+| `isolation_level` | `IsolationLevel` | Requested isolation level (defaults to `READ_COMMITTED`) |
+| `metadata` | `dict[str, Any] \| None` | Arbitrary key-value pairs for cross-cutting concerns |
+
+## When to use
+
+Pass a `ServiceContext` into every application service call for tracing and identity propagation. Use `AuthorizationContext` to bundle the inputs for a permission check. Wrap transactional operations with `TransactionContext` to carry transaction metadata through the boundary.
+
+All context objects are **immutable** — once created, their attributes cannot change. This guarantees that context does not mutate as it passes through layers.
+
+!!! note "Related"
+    See [Application Ports](../application/ports.md) for how contexts are consumed by inbound and outbound ports.

--- a/docs/reference/foundation/rules.md
+++ b/docs/reference/foundation/rules.md
@@ -1,0 +1,29 @@
+# Rules
+
+Rules encapsulate reusable, composable predicates for validation and business logic.
+
+## ValidationRule
+
+`ValidationRule` is an abstract base class for synchronous validation rules. Each rule inspects an arbitrary value and returns a list of `RuleViolationError` objects — empty when the value is valid.
+
+### Contract
+
+```python
+class ValidationRule(ABC):
+    @abstractmethod
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        ...
+```
+
+### Characteristics
+
+- **Stateless** — rules carry no mutable state and can be reused safely across threads and coroutines
+- **Side-effect-free** — `validate` must not perform I/O or mutate the input
+- **Composable** — rules can be combined into composite chains that report every failure
+
+### When to use
+
+Subclass `ValidationRule` for any synchronous validation check. Return `RuleViolationError` instances carrying `ErrorMessage` and `ErrorMetadata` with a field name and error code. Compose multiple rules with `CompositeValidationRule` to validate several constraints at once.
+
+!!! note "Related"
+    See [Domain Validators](../../domain/validators.md) for concrete rule implementations like `RequiredValidator`, `EmailValidator`, `LengthValidator`, and `RangeValidator`.

--- a/docs/reference/foundation/rules.md
+++ b/docs/reference/foundation/rules.md
@@ -26,4 +26,4 @@ class ValidationRule(ABC):
 Subclass `ValidationRule` for any synchronous validation check. Return `RuleViolationError` instances carrying `ErrorMessage` and `ErrorMetadata` with a field name and error code. Compose multiple rules with `CompositeValidationRule` to validate several constraints at once.
 
 !!! note "Related"
-    See [Domain Validators](../../domain/validators.md) for concrete rule implementations like `RequiredValidator`, `EmailValidator`, `LengthValidator`, and `RangeValidator`.
+    See [Domain Validators](../domain/validators.md) for concrete rule implementations like `RequiredValidator`, `EmailValidator`, `LengthValidator`, and `RangeValidator`.

--- a/src/forging_blocks/application/errors/__init__.py
+++ b/src/forging_blocks/application/errors/__init__.py
@@ -1,11 +1,13 @@
 from .concurrency_error import ConcurrencyError
 from .event_bus_error import EventBusError
 from .event_store_error import EventStoreError
+from .transaction_error import TransactionError
 from .unit_of_work_error import UnitOfWorkError
 
 __all__ = [
     "ConcurrencyError",
     "EventBusError",
     "EventStoreError",
+    "TransactionError",
     "UnitOfWorkError",
 ]

--- a/src/forging_blocks/application/errors/transaction_error.py
+++ b/src/forging_blocks/application/errors/transaction_error.py
@@ -1,0 +1,9 @@
+"""Error raised when a transaction operation fails."""
+
+from forging_blocks.foundation.errors.error import Error
+
+
+class TransactionError(Error[dict[str, object]]):
+    """Error raised when a transaction operation fails."""
+
+    pass

--- a/src/forging_blocks/application/ports/inbound/__init__.py
+++ b/src/forging_blocks/application/ports/inbound/__init__.py
@@ -1,5 +1,7 @@
 """Module for inbound ports related to forging blocks application logic."""
 
+from .application_service import ApplicationService
+from .authorization_service import AuthorizationService
 from .message_handler import (
     CommandHandler,
     EventHandler,
@@ -7,11 +9,15 @@ from .message_handler import (
     QueryHandler,
 )
 from .use_case import UseCase
+from .validation_service import ValidationService
 
 __all__ = [
+    "ApplicationService",
+    "AuthorizationService",
     "CommandHandler",
     "EventHandler",
     "MessageHandler",
     "QueryHandler",
     "UseCase",
+    "ValidationService",
 ]

--- a/src/forging_blocks/application/ports/inbound/application_service.py
+++ b/src/forging_blocks/application/ports/inbound/application_service.py
@@ -1,0 +1,18 @@
+"""Inbound port for stateless application-service orchestrators."""
+
+from typing import Protocol, runtime_checkable
+
+from forging_blocks.foundation.ports import InboundPort
+from forging_blocks.foundation.result import Result
+
+
+@runtime_checkable
+class ApplicationService[RequestType, ResponseType](
+    InboundPort[RequestType, Result[ResponseType, object]],
+    Protocol,
+):
+    """Protocol for a stateless application-service orchestrator."""
+
+    async def execute(self, request: RequestType) -> Result[ResponseType, object]:
+        """Execute the business logic for *request*."""
+        ...

--- a/src/forging_blocks/application/ports/inbound/authorization_service.py
+++ b/src/forging_blocks/application/ports/inbound/authorization_service.py
@@ -1,0 +1,39 @@
+"""Inbound port for authorization and permission checking."""
+
+from abc import ABC, abstractmethod
+
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+class AuthorizationService(ABC):
+    """Abstract service that authorizes user actions."""
+
+    @abstractmethod
+    async def check_permission(
+        self,
+        context: AuthorizationContext,
+        permission: Permission,
+    ) -> bool:
+        """Evaluate whether *permission* is granted in *context*."""
+        ...
+
+    @abstractmethod
+    async def check_resource_permission(
+        self,
+        context: AuthorizationContext,
+        resource: str,
+        action: str,
+    ) -> bool:
+        """Evaluate whether *action* on *resource* is permitted in *context*."""
+        ...
+
+    @abstractmethod
+    async def get_user_permissions(self, user_id: str) -> list[Permission]:
+        """Return the effective permissions for *user_id*."""
+        ...
+
+    @abstractmethod
+    async def get_user_roles(self, user_id: str) -> list[str]:
+        """Return the roles assigned to *user_id*."""
+        ...

--- a/src/forging_blocks/application/ports/inbound/validation_service.py
+++ b/src/forging_blocks/application/ports/inbound/validation_service.py
@@ -1,0 +1,20 @@
+"""Inbound port for domain command and query validation."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+
+
+class ValidationService(ABC):
+    """Abstract validation service for commands and queries."""
+
+    @abstractmethod
+    async def validate_command(self, command: Any) -> list[RuleViolationError]:
+        """Validate a domain command."""
+        ...
+
+    @abstractmethod
+    async def validate_query(self, query: Any) -> list[RuleViolationError]:
+        """Validate a domain query."""
+        ...

--- a/src/forging_blocks/application/ports/outbound/__init__.py
+++ b/src/forging_blocks/application/ports/outbound/__init__.py
@@ -13,6 +13,7 @@ from .notifier_port import NotifierPort
 from .query_fetcher_port import QueryFetcherPort
 from .repository_port import ReadOnlyRepositoryPort, RepositoryPort, WriteOnlyRepositoryPort
 from .specification_repository_port import SpecificationRepositoryPort
+from .transaction_manager_port import TransactionManagerPort
 from .unit_of_work_port import UnitOfWorkPort
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "RepositoryPort",
     "WriteOnlyRepositoryPort",
     "SpecificationRepositoryPort",
+    "TransactionManagerPort",
     "UnitOfWorkPort",
 ]

--- a/src/forging_blocks/application/ports/outbound/transaction_manager_port.py
+++ b/src/forging_blocks/application/ports/outbound/transaction_manager_port.py
@@ -1,0 +1,38 @@
+"""Outbound port for transactional boundaries."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from forging_blocks.foundation.context import TransactionContext
+from forging_blocks.foundation.result import Result
+
+
+class TransactionManagerPort[TransactionErrorType](ABC):
+    """Abstract transaction manager for the application layer."""
+
+    @abstractmethod
+    async def begin(self, context: TransactionContext) -> Result[None, TransactionErrorType]:
+        """Start a new transaction."""
+        ...
+
+    @abstractmethod
+    async def commit(self) -> Result[None, TransactionErrorType]:
+        """Commit the current transaction."""
+        ...
+
+    @abstractmethod
+    async def rollback(self) -> Result[None, TransactionErrorType]:
+        """Roll back the current transaction."""
+        ...
+
+    @abstractmethod
+    async def execute_in_transaction[ResponseType](
+        self,
+        fn: Callable[..., Awaitable[ResponseType]],
+        context: TransactionContext,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Result[ResponseType, TransactionErrorType]:
+        """Execute *fn* inside a begin/commit boundary."""
+        ...

--- a/src/forging_blocks/domain/__init__.py
+++ b/src/forging_blocks/domain/__init__.py
@@ -16,20 +16,38 @@ from .errors import (
     EntityIdModificationError,
     EntityIdNoneError,
 )
+from .permissions.composite_permission_checker import CompositePermissionChecker
+from .permissions.permission_checker import PermissionChecker
+from .permissions.resource_permission_checker import ResourcePermissionChecker
+from .permissions.role_based_permission_checker import RoleBasedPermissionChecker
+from .validators.composite_validation_rule import CompositeValidationRule
+from .validators.email_validator import EmailValidator
+from .validators.length_validator import LengthValidator
+from .validators.range_validator import RangeValidator
+from .validators.required_validator import RequiredValidator
 from .value_object import ValueObject
 
 __all__ = [
+    "AggregateRoot",
+    "AggregateVersion",
+    "AndSpecification",
+    "CompositePermissionChecker",
+    "CompositeValidationRule",
     "DraftEntityIsNotHashableError",
+    "EmailValidator",
+    "Entity",
     "EntityIdDeletionError",
     "EntityIdModificationError",
     "EntityIdNoneError",
-    "Entity",
-    "AggregateRoot",
-    "AggregateVersion",
-    "ValueObject",
-    "Specification",
     "ExpressionSpecification",
-    "AndSpecification",
-    "OrSpecification",
+    "LengthValidator",
     "NotSpecification",
+    "OrSpecification",
+    "PermissionChecker",
+    "RangeValidator",
+    "RequiredValidator",
+    "ResourcePermissionChecker",
+    "RoleBasedPermissionChecker",
+    "Specification",
+    "ValueObject",
 ]

--- a/src/forging_blocks/domain/permissions/__init__.py
+++ b/src/forging_blocks/domain/permissions/__init__.py
@@ -1,0 +1,13 @@
+"""Domain permission checker implementations."""
+
+from .composite_permission_checker import CompositePermissionChecker
+from .permission_checker import PermissionChecker
+from .resource_permission_checker import ResourcePermissionChecker
+from .role_based_permission_checker import RoleBasedPermissionChecker
+
+__all__ = [
+    "CompositePermissionChecker",
+    "PermissionChecker",
+    "ResourcePermissionChecker",
+    "RoleBasedPermissionChecker",
+]

--- a/src/forging_blocks/domain/permissions/composite_permission_checker.py
+++ b/src/forging_blocks/domain/permissions/composite_permission_checker.py
@@ -1,0 +1,20 @@
+"""Composite permission checker with OR logic."""
+
+from forging_blocks.domain.permissions.permission_checker import PermissionChecker
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+class CompositePermissionChecker:
+    """Combines multiple :class:`PermissionChecker` instances with OR logic."""
+
+    __match_args__ = ("_checkers",)
+
+    def __init__(self, checkers: list[PermissionChecker]) -> None:
+        self._checkers = checkers
+
+    async def check(self, context: AuthorizationContext, permission: Permission) -> bool:
+        for checker in self._checkers:
+            if await checker.check(context, permission):
+                return True
+        return False

--- a/src/forging_blocks/domain/permissions/permission_checker.py
+++ b/src/forging_blocks/domain/permissions/permission_checker.py
@@ -1,0 +1,15 @@
+"""Protocol for permission-checking implementations."""
+
+from typing import Protocol, runtime_checkable
+
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+@runtime_checkable
+class PermissionChecker(Protocol):
+    """Protocol for any callable that decides whether a permission is granted."""
+
+    async def check(self, context: AuthorizationContext, permission: Permission) -> bool:
+        """Return ``True`` if *permission* is granted in *context*."""
+        ...

--- a/src/forging_blocks/domain/permissions/resource_permission_checker.py
+++ b/src/forging_blocks/domain/permissions/resource_permission_checker.py
@@ -1,0 +1,27 @@
+"""Resource-based permission checker implementation."""
+
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+class ResourcePermissionChecker:
+    """Grants permissions based on a resource-type-to-permission mapping.
+
+    Args:
+        resource_permissions: A dictionary mapping resource-type names
+            (``str``) to the list of :class:`Permission` values allowed
+            for that resource type.
+    """
+
+    __match_args__ = ("_resource_permissions",)
+
+    def __init__(self, resource_permissions: dict[str, list[Permission]]) -> None:
+        self._resource_permissions = resource_permissions
+
+    async def check(self, context: AuthorizationContext, permission: Permission) -> bool:
+        if not context.resource_type:
+            return False
+        allowed = self._resource_permissions.get(context.resource_type)
+        if allowed is None:
+            return False
+        return permission in allowed

--- a/src/forging_blocks/domain/permissions/role_based_permission_checker.py
+++ b/src/forging_blocks/domain/permissions/role_based_permission_checker.py
@@ -1,0 +1,27 @@
+"""Role-based permission checker implementation."""
+
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+class RoleBasedPermissionChecker:
+    """Grants permissions based on a static role-to-permission mapping.
+
+    Args:
+        role_permissions: A dictionary mapping role names (``str``) to the list
+            of :class:`Permission` values that role is allowed.
+    """
+
+    __match_args__ = ("_role_permissions",)
+
+    def __init__(self, role_permissions: dict[str, list[Permission]]) -> None:
+        self._role_permissions = role_permissions
+
+    async def check(self, context: AuthorizationContext, permission: Permission) -> bool:
+        if not context.roles:
+            return False
+        for role in context.roles:
+            allowed = self._role_permissions.get(role)
+            if allowed is not None and permission in allowed:
+                return True
+        return False

--- a/src/forging_blocks/domain/validators/__init__.py
+++ b/src/forging_blocks/domain/validators/__init__.py
@@ -1,0 +1,15 @@
+"""Domain validation rule implementations."""
+
+from .composite_validation_rule import CompositeValidationRule
+from .email_validator import EmailValidator
+from .length_validator import LengthValidator
+from .range_validator import RangeValidator
+from .required_validator import RequiredValidator
+
+__all__ = [
+    "CompositeValidationRule",
+    "EmailValidator",
+    "LengthValidator",
+    "RangeValidator",
+    "RequiredValidator",
+]

--- a/src/forging_blocks/domain/validators/composite_validation_rule.py
+++ b/src/forging_blocks/domain/validators/composite_validation_rule.py
@@ -1,0 +1,23 @@
+"""Combines multiple validation rules into a single rule."""
+
+from typing import Any
+
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+from forging_blocks.foundation.rules import ValidationRule
+
+
+class CompositeValidationRule(ValidationRule):
+    """Combines multiple ``ValidationRule`` instances into a single rule.
+
+    All rules are evaluated and their errors are concatenated (no
+    short-circuit), so every validation failure is reported.
+    """
+
+    def __init__(self, rules: list[ValidationRule]) -> None:
+        self._rules = rules
+
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        errors: list[RuleViolationError] = []
+        for rule in self._rules:
+            errors.extend(rule.validate(value))
+        return errors

--- a/src/forging_blocks/domain/validators/email_validator.py
+++ b/src/forging_blocks/domain/validators/email_validator.py
@@ -1,0 +1,30 @@
+"""Validator for email address format."""
+
+import re
+from typing import Any
+
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+from forging_blocks.foundation.rules import ValidationRule
+
+
+class EmailValidator(ValidationRule):
+    """Validates that a string value is a well-formed email address."""
+
+    _EMAIL_PATTERN: re.Pattern[str] = re.compile(
+        r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}"
+        r"[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$"
+    )
+
+    def __init__(self, field: str) -> None:
+        self._field = field
+
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        if value is None or not isinstance(value, str) or not self._EMAIL_PATTERN.match(value):
+            return [
+                RuleViolationError(
+                    ErrorMessage(f"'{self._field}' must be a valid email address."),
+                    ErrorMetadata(context={"field": self._field, "code": "invalid_email"}),
+                )
+            ]
+        return []

--- a/src/forging_blocks/domain/validators/length_validator.py
+++ b/src/forging_blocks/domain/validators/length_validator.py
@@ -1,0 +1,54 @@
+"""Validator for string length constraints."""
+
+from typing import Any
+
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+from forging_blocks.foundation.rules import ValidationRule
+
+
+class LengthValidator(ValidationRule):
+    """Validates that a string's length falls within a ``[minimum, maximum]`` range."""
+
+    def __init__(
+        self,
+        field: str,
+        minimum_length: int = 0,
+        maximum_length: int | None = None,
+    ) -> None:
+        self._field = field
+        self._minimum_length = minimum_length
+        self._maximum_length = maximum_length
+
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        if not isinstance(value, str):
+            return [
+                RuleViolationError(
+                    ErrorMessage(f"'{self._field}' must be a string."),
+                    ErrorMetadata(context={"field": self._field, "code": "invalid_type"}),
+                )
+            ]
+
+        errors: list[RuleViolationError] = []
+
+        if len(value) < self._minimum_length:
+            errors.append(
+                RuleViolationError(
+                    ErrorMessage(
+                        f"'{self._field}' must be at least {self._minimum_length} characters."
+                    ),
+                    ErrorMetadata(context={"field": self._field, "code": "minimum_length"}),
+                )
+            )
+
+        if self._maximum_length is not None and len(value) > self._maximum_length:
+            errors.append(
+                RuleViolationError(
+                    ErrorMessage(
+                        f"'{self._field}' must be at most {self._maximum_length} characters."
+                    ),
+                    ErrorMetadata(context={"field": self._field, "code": "maximum_length"}),
+                )
+            )
+
+        return errors

--- a/src/forging_blocks/domain/validators/range_validator.py
+++ b/src/forging_blocks/domain/validators/range_validator.py
@@ -1,0 +1,50 @@
+"""Validator for numeric value ranges."""
+
+from typing import Any
+
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+from forging_blocks.foundation.rules import ValidationRule
+
+
+class RangeValidator(ValidationRule):
+    """Validates that a numeric value falls within a ``[minimum, maximum]`` range."""
+
+    def __init__(
+        self,
+        field: str,
+        minimum_value: int | float | None = None,
+        maximum_value: int | float | None = None,
+    ) -> None:
+        self._field = field
+        self._minimum_value = minimum_value
+        self._maximum_value = maximum_value
+
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        if not isinstance(value, (int, float)):
+            return [
+                RuleViolationError(
+                    ErrorMessage(f"'{self._field}' must be a number."),
+                    ErrorMetadata(context={"field": self._field, "code": "invalid_type"}),
+                )
+            ]
+
+        errors: list[RuleViolationError] = []
+
+        if self._minimum_value is not None and value < self._minimum_value:
+            errors.append(
+                RuleViolationError(
+                    ErrorMessage(f"'{self._field}' must be at least {self._minimum_value}."),
+                    ErrorMetadata(context={"field": self._field, "code": "minimum_value"}),
+                )
+            )
+
+        if self._maximum_value is not None and value > self._maximum_value:
+            errors.append(
+                RuleViolationError(
+                    ErrorMessage(f"'{self._field}' must be at most {self._maximum_value}."),
+                    ErrorMetadata(context={"field": self._field, "code": "maximum_value"}),
+                )
+            )
+
+        return errors

--- a/src/forging_blocks/domain/validators/required_validator.py
+++ b/src/forging_blocks/domain/validators/required_validator.py
@@ -1,0 +1,24 @@
+"""Validator that fails when a value is None or an empty string."""
+
+from typing import Any
+
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+from forging_blocks.foundation.rules import ValidationRule
+
+
+class RequiredValidator(ValidationRule):
+    """Fails when the value is ``None`` or an empty string."""
+
+    def __init__(self, field: str) -> None:
+        self._field = field
+
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        if value is None or value == "":
+            return [
+                RuleViolationError(
+                    ErrorMessage(f"'{self._field}' is required."),
+                    ErrorMetadata(context={"field": self._field, "code": "required"}),
+                )
+            ]
+        return []

--- a/src/forging_blocks/foundation/__init__.py
+++ b/src/forging_blocks/foundation/__init__.py
@@ -1,5 +1,6 @@
 """ForgingBlocks foundation modules."""
 
+from .context import AuthorizationContext, ServiceContext, TransactionContext
 from .errors import (
     CantModifyImmutableAttributeError,
     CombinedErrors,
@@ -17,15 +18,18 @@ from .errors import (
     ValidationFieldErrors,
 )
 from .identified import Identified
+from .isolation_level import IsolationLevel
 from .mapper import Mapper
 from .messages import Command, Event, Message, Query
 from .meta import FinalABCMeta, FinalMeta, runtime_final
+from .permission import Permission
 from .ports import (
     InboundPort,
     OutboundPort,
     Port,
 )
 from .result import Err, Ok, Result
+from .rules import ValidationRule
 from .specification import (
     AndSpecification,
     ComposableSpecification,
@@ -37,40 +41,46 @@ from .specification import (
 from .value_object import ValueObject
 
 __all__ = [
-    "Port",
-    "InboundPort",
-    "OutboundPort",
-    "Mapper",
-    "Result",
-    "Ok",
-    "Err",
-    "Error",
-    "ValidationFieldErrors",
-    "CombinedValidationErrors",
-    "NoneNotAllowedError",
+    "AndSpecification",
+    "AuthorizationContext",
     "CantModifyImmutableAttributeError",
     "CombinedErrors",
     "CombinedRuleViolationErrors",
+    "CombinedValidationErrors",
+    "Command",
+    "ComposableSpecification",
+    "Err",
+    "Error",
     "ErrorMessage",
     "ErrorMetadata",
-    "FieldReference",
+    "Event",
+    "ExpressionSpecification",
     "FieldErrors",
-    "Identified",
-    "RuleViolationError",
-    "ValidationError",
+    "FieldReference",
     "FinalABCMeta",
     "FinalMeta",
-    "runtime_final",
-    "ResultAccessError",
-    "Command",
-    "Query",
-    "Event",
+    "Identified",
+    "InboundPort",
+    "IsolationLevel",
+    "Mapper",
     "Message",
-    "AndSpecification",
-    "ComposableSpecification",
-    "ExpressionSpecification",
+    "NoneNotAllowedError",
     "NotSpecification",
+    "Ok",
     "OrSpecification",
+    "OutboundPort",
+    "Permission",
+    "Port",
+    "Query",
+    "Result",
+    "ResultAccessError",
+    "RuleViolationError",
+    "runtime_final",
+    "ServiceContext",
     "Specification",
+    "TransactionContext",
+    "ValidationError",
+    "ValidationFieldErrors",
+    "ValidationRule",
     "ValueObject",
 ]

--- a/src/forging_blocks/foundation/context/__init__.py
+++ b/src/forging_blocks/foundation/context/__init__.py
@@ -1,0 +1,11 @@
+"""Context objects carried through application boundaries."""
+
+from .authorization_context import AuthorizationContext
+from .service_context import ServiceContext
+from .transaction_context import TransactionContext
+
+__all__ = [
+    "AuthorizationContext",
+    "ServiceContext",
+    "TransactionContext",
+]

--- a/src/forging_blocks/foundation/context/authorization_context.py
+++ b/src/forging_blocks/foundation/context/authorization_context.py
@@ -1,0 +1,32 @@
+"""Authorization context bundled for a single authorization decision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from forging_blocks.foundation.autofreeze import auto_freeze
+
+
+@auto_freeze
+@dataclass(frozen=True)
+class AuthorizationContext:
+    """Bundles the information needed for a single authorization decision.
+
+    Args:
+        user_id: The unique identifier of the user requesting access.
+        roles: Roles assigned to the user (e.g. ``["admin", "editor"]``).
+        resource_id: Optional identifier of the resource being accessed.
+        resource_type: Optional discriminator for the resource kind
+            (e.g. ``"document"``, ``"project"``).
+        action: Optional name of the action being performed
+            (e.g. ``"publish"``, ``"archive"``).
+        metadata: Arbitrary key-value pairs that checkers may inspect.
+    """
+
+    user_id: str
+    roles: list[str] | None = None
+    resource_id: str | None = None
+    resource_type: str | None = None
+    action: str | None = None
+    metadata: dict[str, Any] | None = None

--- a/src/forging_blocks/foundation/context/service_context.py
+++ b/src/forging_blocks/foundation/context/service_context.py
@@ -1,0 +1,29 @@
+"""Immutable context carried through every application-service call."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from forging_blocks.foundation.autofreeze import auto_freeze
+
+
+@auto_freeze
+@dataclass(frozen=True)
+class ServiceContext:
+    """Immutable context carried through every application-service call.
+
+    Args:
+        correlation_id: A unique identifier that traces the entire
+            request/response lifecycle.  Auto-generated when omitted.
+        user_id: The identifier of the authenticated user, if any.
+        permissions: The permissions held by the current user.
+        metadata: Arbitrary key-value pairs for cross-cutting concerns
+            (tracing, feature flags, tenant id, etc.).
+    """
+
+    correlation_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    user_id: str | None = None
+    permissions: list[str] = field(default_factory=list[str])
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])

--- a/src/forging_blocks/foundation/context/transaction_context.py
+++ b/src/forging_blocks/foundation/context/transaction_context.py
@@ -1,0 +1,32 @@
+"""Metadata for a single transactional boundary."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from forging_blocks.foundation.autofreeze import auto_freeze
+from forging_blocks.foundation.isolation_level import IsolationLevel
+
+
+@auto_freeze
+@dataclass(frozen=True)
+class TransactionContext:
+    """Metadata for a single transactional boundary.
+
+    Args:
+        transaction_id: Unique identifier for the transaction.
+            Auto-generated when omitted.
+        started_at: UTC timestamp marking when the transaction began.
+            Defaults to the current time.
+        isolation_level: The isolation level requested for this
+            transaction.  Defaults to ``READ_COMMITTED``.
+        metadata: Arbitrary key-value pairs for cross-cutting concerns.
+    """
+
+    transaction_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    isolation_level: IsolationLevel = IsolationLevel.READ_COMMITTED
+    metadata: dict[str, Any] | None = None

--- a/src/forging_blocks/foundation/isolation_level.py
+++ b/src/forging_blocks/foundation/isolation_level.py
@@ -1,0 +1,12 @@
+"""Standard ANSI SQL isolation levels."""
+
+from enum import StrEnum
+
+
+class IsolationLevel(StrEnum):
+    """Standard ANSI SQL isolation levels."""
+
+    READ_UNCOMMITTED = "read_uncommitted"
+    READ_COMMITTED = "read_committed"
+    REPEATABLE_READ = "repeatable_read"
+    SERIALIZABLE = "serializable"

--- a/src/forging_blocks/foundation/permission.py
+++ b/src/forging_blocks/foundation/permission.py
@@ -1,0 +1,12 @@
+"""Granular permission identifiers for authorization checks."""
+
+from enum import StrEnum
+
+
+class Permission(StrEnum):
+    """Granular permission identifiers for authorization checks."""
+
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    ADMIN = "admin"

--- a/src/forging_blocks/foundation/rules/__init__.py
+++ b/src/forging_blocks/foundation/rules/__init__.py
@@ -1,0 +1,7 @@
+"""Composable validation rules."""
+
+from .validation_rule import ValidationRule
+
+__all__ = [
+    "ValidationRule",
+]

--- a/src/forging_blocks/foundation/rules/validation_rule.py
+++ b/src/forging_blocks/foundation/rules/validation_rule.py
@@ -1,0 +1,15 @@
+"""Abstract base class for a synchronous validation rule."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+
+
+class ValidationRule(ABC):
+    """Abstract base class for a synchronous validation rule."""
+
+    @abstractmethod
+    def validate(self, value: Any) -> list[RuleViolationError]:
+        """Validate *value* and return any errors found."""
+        ...

--- a/tests/fixtures/fake_command_runner.py
+++ b/tests/fixtures/fake_command_runner.py
@@ -1,0 +1,38 @@
+"""Fake CommandRunner implementation for infrastructure tests.
+
+Configurable responses replace real subprocess calls. Tests verify
+behaviour through recorded calls and configured outputs, not
+through mock interaction assertions.
+"""
+
+from scripts.release.infrastructure.commons.process import CommandRunner
+
+
+class FakeCommandRunner(CommandRunner):
+    """State-based CommandRunner fake.
+
+    ``responses`` is an ordered list — each ``run()`` call pops the
+    first entry.  Entries may be a ``str`` (success) or an
+    ``Exception`` to raise.
+    """
+
+    def __init__(self, *configured_outputs: str | Exception) -> None:
+        self.configured_outputs: list[str | Exception] = list(configured_outputs)
+        self.calls: list[tuple[list[str], bool, bool]] = []
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        check: bool = True,
+        suppress_error_log: bool = False,
+    ) -> str:
+        self.calls.append((cmd, check, suppress_error_log))
+
+        if not self.configured_outputs:
+            return ""
+
+        output = self.configured_outputs.pop(0)
+        if isinstance(output, Exception):
+            raise output
+        return output

--- a/tests/fixtures/fake_event_publisher.py
+++ b/tests/fixtures/fake_event_publisher.py
@@ -1,0 +1,24 @@
+"""Fake EventPublisher implementation for infrastructure tests.
+
+Tracks published events so tests can verify behaviour through
+state inspection rather than mock interaction assertions.
+"""
+
+from typing import Any
+
+
+class FakeEventPublisher:
+    """State-based EventPublisherPort fake.
+
+    Records every published event for later assertion. Optionally
+    raises a configured error on publish to test error handling.
+    """
+
+    def __init__(self, should_raise: Exception | None = None) -> None:
+        self.published_events: list[Any] = []
+        self._should_raise = should_raise
+
+    async def publish(self, event: Any) -> None:
+        if self._should_raise is not None:
+            raise self._should_raise
+        self.published_events.append(event)

--- a/tests/fixtures/fake_message_bus.py
+++ b/tests/fixtures/fake_message_bus.py
@@ -1,0 +1,27 @@
+"""Fake MessageBus implementation for infrastructure tests.
+
+Tracks dispatched messages so tests can verify behaviour through
+state inspection rather than mock interaction assertions.
+"""
+
+from typing import Any
+
+
+class FakeMessageBus:
+    """State-based MessageBusPort fake.
+
+    Records every dispatched message for later assertion. No mocking
+    framework — just a plain object that honours the protocol.
+    """
+
+    def __init__(self, dispatch_result: Any = None) -> None:
+        self.dispatched_messages: list[Any] = []
+        self._dispatch_result = dispatch_result
+
+    async def dispatch(self, message: Any) -> Any:
+        self.dispatched_messages.append(message)
+        return self._dispatch_result
+
+    def pop_message(self) -> Any | None:
+        """Return and remove the most recent dispatched message, or None."""
+        return self.dispatched_messages.pop() if self.dispatched_messages else None

--- a/tests/forging_blocks/application/errors/test_transaction_error.py
+++ b/tests/forging_blocks/application/errors/test_transaction_error.py
@@ -1,0 +1,22 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.application.errors.transaction_error import TransactionError
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+
+
+@pytest.mark.unit
+class TestTransactionError:
+    def test_when_created_with_message_then_extends_error(self) -> None:
+        error = TransactionError(ErrorMessage("commit failed"))
+
+        assert isinstance(error, TransactionError)
+        assert str(error) == "TransactionError: commit failed"
+
+    def test_when_created_with_message_and_metadata_then_stores_both(self) -> None:
+        metadata = ErrorMetadata[dict[str, object]](context={"transaction_identifier": "abc"})
+        error = TransactionError(ErrorMessage("rollback"), metadata)
+
+        assert error.message.value == "rollback"
+        assert error.metadata.context == {"transaction_identifier": "abc"}

--- a/tests/forging_blocks/application/ports/inbound/test_application_service.py
+++ b/tests/forging_blocks/application/ports/inbound/test_application_service.py
@@ -1,0 +1,39 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.application.ports.inbound.application_service import ApplicationService
+from forging_blocks.foundation.result import Err, Ok
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestApplicationService:
+    async def test_when_implementation_returns_ok_then_is_ok(self) -> None:
+        class RegisterUserService:
+            async def execute(self, request: str) -> Ok[str, object]:
+                del request
+                return Ok("user-42")
+
+        service = RegisterUserService()
+        assert isinstance(service, ApplicationService)
+
+        result = await service.execute("register")
+        assert result.is_ok
+        assert result.value == "user-42"
+
+    async def test_when_implementation_returns_err_then_is_err(self) -> None:
+        class FailingService:
+            async def execute(self, request: str) -> Err[object, str]:
+                del request
+                return Err("failed")
+
+        result = await FailingService().execute("boom")
+        assert result.is_err
+        assert result.error == "failed"
+
+    async def test_when_protocol_not_implemented_then_not_instance(self) -> None:
+        class NotAService:
+            pass
+
+        assert not isinstance(NotAService(), ApplicationService)

--- a/tests/forging_blocks/application/ports/inbound/test_authorization_service.py
+++ b/tests/forging_blocks/application/ports/inbound/test_authorization_service.py
@@ -1,0 +1,80 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.application.ports.inbound.authorization_service import AuthorizationService
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestAuthorizationService:
+    async def test_when_check_permission_granted_then_returns_true(self) -> None:
+        class PermissiveAuthorizationService(AuthorizationService):
+            async def check_permission(
+                self,
+                context: AuthorizationContext,
+                permission: Permission,
+            ) -> bool:
+                del context, permission
+                return True
+
+            async def check_resource_permission(
+                self,
+                context: AuthorizationContext,
+                resource: str,
+                action: str,
+            ) -> bool:
+                del context, resource, action
+                return True
+
+            async def get_user_permissions(self, user_id: str) -> list[Permission]:
+                del user_id
+                return [Permission.READ]
+
+            async def get_user_roles(self, user_id: str) -> list[str]:
+                del user_id
+                return ["admin"]
+
+        service = PermissiveAuthorizationService()
+        context = AuthorizationContext(user_id="user-1")
+
+        assert await service.check_permission(context, Permission.READ) is True
+
+    async def test_when_check_permission_denied_then_returns_false(self) -> None:
+        class RestrictiveAuthorizationService(AuthorizationService):
+            async def check_permission(
+                self,
+                context: AuthorizationContext,
+                permission: Permission,
+            ) -> bool:
+                del context, permission
+                return False
+
+            async def check_resource_permission(
+                self,
+                context: AuthorizationContext,
+                resource: str,
+                action: str,
+            ) -> bool:
+                del context, resource, action
+                return False
+
+            async def get_user_permissions(self, user_id: str) -> list[Permission]:
+                del user_id
+                return []
+
+            async def get_user_roles(self, user_id: str) -> list[str]:
+                del user_id
+                return []
+
+        service = RestrictiveAuthorizationService()
+
+        assert (
+            await service.check_permission(
+                AuthorizationContext(user_id="user-1"),
+                Permission.ADMIN,
+            )
+            is False
+        )

--- a/tests/forging_blocks/application/ports/inbound/test_validation_service.py
+++ b/tests/forging_blocks/application/ports/inbound/test_validation_service.py
@@ -1,0 +1,41 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.application.ports.inbound.validation_service import ValidationService
+from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestValidationService:
+    async def test_when_concrete_implementation_then_returns_command_errors(self) -> None:
+        class StrictValidator(ValidationService):
+            async def validate_command(self, command: object) -> list[RuleViolationError]:
+                return [RuleViolationError(ErrorMessage("invalid"))]
+
+            async def validate_query(self, query: object) -> list[RuleViolationError]:
+                del query
+                return []
+
+        service = StrictValidator()
+        errors = await service.validate_command("data")
+
+        assert len(errors) == 1
+        assert str(errors[0]) == "RuleViolationError: invalid"
+
+    async def test_when_valid_query_then_returns_empty(self) -> None:
+        class PermissiveValidator(ValidationService):
+            async def validate_command(self, command: object) -> list[RuleViolationError]:
+                del command
+                return []
+
+            async def validate_query(self, query: object) -> list[RuleViolationError]:
+                del query
+                return []
+
+        service = PermissiveValidator()
+        errors = await service.validate_query("any")
+
+        assert errors == []

--- a/tests/forging_blocks/domain/permissions/test_composite_permission_checker.py
+++ b/tests/forging_blocks/domain/permissions/test_composite_permission_checker.py
@@ -1,0 +1,43 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.permissions.composite_permission_checker import (
+    CompositePermissionChecker,
+)
+from forging_blocks.domain.permissions.role_based_permission_checker import (
+    RoleBasedPermissionChecker,
+)
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestCompositePermissionChecker:
+    async def test_when_any_inner_grants_then_grants(self) -> None:
+        checker = CompositePermissionChecker(
+            [
+                RoleBasedPermissionChecker({"admin": [Permission.READ]}),
+                RoleBasedPermissionChecker({"user": []}),
+            ]
+        )
+        context = AuthorizationContext(user_id="user-1", roles=["admin"])
+
+        assert await checker.check(context, Permission.READ) is True
+
+    async def test_when_all_deny_then_denies(self) -> None:
+        checker = CompositePermissionChecker(
+            [
+                RoleBasedPermissionChecker({"user": [Permission.READ]}),
+            ]
+        )
+        context = AuthorizationContext(user_id="user-1", roles=["guest"])
+
+        assert await checker.check(context, Permission.READ) is False
+
+    async def test_when_empty_checkers_then_denies(self) -> None:
+        checker = CompositePermissionChecker([])
+        context = AuthorizationContext(user_id="user-1")
+
+        assert await checker.check(context, Permission.READ) is False

--- a/tests/forging_blocks/domain/permissions/test_permission_checker.py
+++ b/tests/forging_blocks/domain/permissions/test_permission_checker.py
@@ -1,0 +1,18 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.permissions.permission_checker import PermissionChecker
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+@pytest.mark.unit
+class TestPermissionCheckerProtocol:
+    def test_when_implements_async_check_then_is_permission_checker(self) -> None:
+        class CustomChecker:
+            async def check(self, context: AuthorizationContext, permission: Permission) -> bool:
+                del context, permission
+                return True
+
+        assert isinstance(CustomChecker(), PermissionChecker)

--- a/tests/forging_blocks/domain/permissions/test_resource_permission_checker.py
+++ b/tests/forging_blocks/domain/permissions/test_resource_permission_checker.py
@@ -1,0 +1,35 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.permissions.resource_permission_checker import ResourcePermissionChecker
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestResourcePermissionChecker:
+    async def test_when_resource_type_allows_permission_then_grants(self) -> None:
+        checker = ResourcePermissionChecker({"document": [Permission.READ, Permission.WRITE]})
+        context = AuthorizationContext(user_id="user-1", resource_type="document")
+
+        assert await checker.check(context, Permission.READ) is True
+
+    async def test_when_resource_type_lacks_permission_then_denies(self) -> None:
+        checker = ResourcePermissionChecker({"image": [Permission.READ]})
+        context = AuthorizationContext(user_id="user-1", resource_type="image")
+
+        assert await checker.check(context, Permission.DELETE) is False
+
+    async def test_when_resource_type_missing_then_denies(self) -> None:
+        checker = ResourcePermissionChecker({"document": [Permission.READ]})
+        context = AuthorizationContext(user_id="user-1")
+
+        assert await checker.check(context, Permission.READ) is False
+
+    async def test_when_resource_type_unknown_then_denies(self) -> None:
+        checker = ResourcePermissionChecker({"document": [Permission.READ]})
+        context = AuthorizationContext(user_id="user-1", resource_type="unknown_type")
+
+        assert await checker.check(context, Permission.READ) is False

--- a/tests/forging_blocks/domain/permissions/test_role_based_permission_checker.py
+++ b/tests/forging_blocks/domain/permissions/test_role_based_permission_checker.py
@@ -1,0 +1,31 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.permissions.role_based_permission_checker import (
+    RoleBasedPermissionChecker,
+)
+from forging_blocks.foundation.context import AuthorizationContext
+from forging_blocks.foundation.permission import Permission
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRoleBasedPermissionChecker:
+    async def test_when_role_has_permission_then_grants(self) -> None:
+        checker = RoleBasedPermissionChecker({"admin": [Permission.READ, Permission.WRITE]})
+        context = AuthorizationContext(user_id="user-1", roles=["admin"])
+
+        assert await checker.check(context, Permission.READ) is True
+
+    async def test_when_role_lacks_permission_then_denies(self) -> None:
+        checker = RoleBasedPermissionChecker({"user": [Permission.READ]})
+        context = AuthorizationContext(user_id="user-1", roles=["user"])
+
+        assert await checker.check(context, Permission.DELETE) is False
+
+    async def test_when_no_roles_then_denies(self) -> None:
+        checker = RoleBasedPermissionChecker({"admin": [Permission.READ]})
+        context = AuthorizationContext(user_id="user-1")
+
+        assert await checker.check(context, Permission.READ) is False

--- a/tests/forging_blocks/domain/validators/test_composite_validation_rule.py
+++ b/tests/forging_blocks/domain/validators/test_composite_validation_rule.py
@@ -1,0 +1,45 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.validators.composite_validation_rule import CompositeValidationRule
+from forging_blocks.domain.validators.email_validator import EmailValidator
+from forging_blocks.domain.validators.length_validator import LengthValidator
+from forging_blocks.domain.validators.required_validator import RequiredValidator
+
+
+@pytest.mark.unit
+class TestCompositeValidationRule:
+    def test_when_all_pass_then_no_error(self) -> None:
+        composite = CompositeValidationRule(
+            [
+                RequiredValidator("email"),
+                EmailValidator("email"),
+            ]
+        )
+        result = composite.validate("user@example.com")
+
+        assert result == []
+
+    def test_when_one_fails_then_collects_error(self) -> None:
+        composite = CompositeValidationRule(
+            [
+                RequiredValidator("email"),
+                EmailValidator("email"),
+            ]
+        )
+        result = composite.validate("invalid")
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "invalid_email"
+
+    def test_when_multiple_fail_then_collects_all(self) -> None:
+        composite = CompositeValidationRule(
+            [
+                RequiredValidator("name"),
+                LengthValidator("name", minimum_length=5),
+            ]
+        )
+        result = composite.validate("ab")
+
+        assert len(result) == 1

--- a/tests/forging_blocks/domain/validators/test_email_validator.py
+++ b/tests/forging_blocks/domain/validators/test_email_validator.py
@@ -1,0 +1,25 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.validators.email_validator import EmailValidator
+
+
+@pytest.mark.unit
+class TestEmailValidator:
+    def test_when_valid_email_then_no_error(self) -> None:
+        result = EmailValidator("email").validate("user@example.com")
+
+        assert result == []
+
+    def test_when_invalid_format_then_error(self) -> None:
+        result = EmailValidator("email").validate("not-an-email")
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "invalid_email"
+
+    def test_when_none_then_error(self) -> None:
+        result = EmailValidator("email").validate(None)
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "invalid_email"

--- a/tests/forging_blocks/domain/validators/test_length_validator.py
+++ b/tests/forging_blocks/domain/validators/test_length_validator.py
@@ -1,0 +1,33 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.validators.length_validator import LengthValidator
+
+
+@pytest.mark.unit
+class TestLengthValidator:
+    def test_when_within_range_then_no_error(self) -> None:
+        result = LengthValidator("password", minimum_length=8, maximum_length=20).validate(
+            "ten-chars!"
+        )
+
+        assert result == []
+
+    def test_when_too_short_then_error(self) -> None:
+        result = LengthValidator("password", minimum_length=8).validate("abc")
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "minimum_length"
+
+    def test_when_too_long_then_error(self) -> None:
+        result = LengthValidator("password", maximum_length=5).validate("abcdef")
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "maximum_length"
+
+    def test_when_not_a_string_then_error(self) -> None:
+        result = LengthValidator("password").validate(123)
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "invalid_type"

--- a/tests/forging_blocks/domain/validators/test_range_validator.py
+++ b/tests/forging_blocks/domain/validators/test_range_validator.py
@@ -1,0 +1,36 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.validators.range_validator import RangeValidator
+
+
+@pytest.mark.unit
+class TestRangeValidator:
+    def test_when_within_range_then_no_error(self) -> None:
+        result = RangeValidator("age", minimum_value=0, maximum_value=150).validate(30)
+
+        assert result == []
+
+    def test_when_below_minimum_then_error(self) -> None:
+        result = RangeValidator("age", minimum_value=0).validate(-5)
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "minimum_value"
+
+    def test_when_above_maximum_then_error(self) -> None:
+        result = RangeValidator("age", maximum_value=150).validate(200)
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "maximum_value"
+
+    def test_when_float_value_then_supported(self) -> None:
+        result = RangeValidator("score", minimum_value=0.0, maximum_value=1.0).validate(0.5)
+
+        assert result == []
+
+    def test_when_not_numeric_then_error(self) -> None:
+        result = RangeValidator("age").validate("thirty")
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "invalid_type"

--- a/tests/forging_blocks/domain/validators/test_required_validator.py
+++ b/tests/forging_blocks/domain/validators/test_required_validator.py
@@ -1,0 +1,25 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.domain.validators.required_validator import RequiredValidator
+
+
+@pytest.mark.unit
+class TestRequiredValidator:
+    def test_when_value_is_none_then_error(self) -> None:
+        result = RequiredValidator("name").validate(None)
+
+        assert len(result) == 1
+        assert result[0].context == {"field": "name", "code": "required"}
+
+    def test_when_value_is_empty_string_then_error(self) -> None:
+        result = RequiredValidator("name").validate("")
+
+        assert len(result) == 1
+        assert result[0].context["code"] == "required"
+
+    def test_when_value_is_non_empty_then_no_error(self) -> None:
+        result = RequiredValidator("name").validate("Alice")
+
+        assert result == []

--- a/tests/forging_blocks/foundation/context/test_authorization_context.py
+++ b/tests/forging_blocks/foundation/context/test_authorization_context.py
@@ -1,0 +1,31 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.foundation.context import AuthorizationContext
+
+
+@pytest.mark.unit
+class TestAuthorizationContext:
+    def test_when_created_with_user_identifier_then_stores_it(self) -> None:
+        context = AuthorizationContext(user_id="user-1")
+
+        assert context.user_id == "user-1"
+        assert context.roles is None
+
+    def test_when_created_with_full_arguments_then_stores_all(self) -> None:
+        context = AuthorizationContext(
+            user_id="user-1",
+            roles=["admin", "editor"],
+            resource_id="document-42",
+            resource_type="document",
+            action="publish",
+            metadata={"ip_address": "127.0.0.1"},
+        )
+
+        assert context.user_id == "user-1"
+        assert context.roles == ["admin", "editor"]
+        assert context.resource_id == "document-42"
+        assert context.resource_type == "document"
+        assert context.action == "publish"
+        assert context.metadata == {"ip_address": "127.0.0.1"}

--- a/tests/forging_blocks/foundation/context/test_service_context.py
+++ b/tests/forging_blocks/foundation/context/test_service_context.py
@@ -1,0 +1,39 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import uuid
+
+import pytest
+
+from forging_blocks.foundation.context import ServiceContext
+
+
+@pytest.mark.unit
+class TestServiceContext:
+    def test_when_created_without_arguments_then_auto_generates_correlation_identifier(
+        self,
+    ) -> None:
+        context = ServiceContext()
+
+        assert isinstance(context.correlation_id, uuid.UUID)
+        assert context.user_id is None
+        assert context.permissions == []
+        assert context.metadata == {}
+
+    def test_when_created_with_arguments_then_stores_values(self) -> None:
+        context = ServiceContext(
+            correlation_id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+            user_id="user-1",
+            permissions=["read", "write"],
+            metadata={"tenant": "acme"},
+        )
+
+        assert context.correlation_id == uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert context.user_id == "user-1"
+        assert context.permissions == ["read", "write"]
+        assert context.metadata == {"tenant": "acme"}
+
+    def test_when_two_default_contexts_then_have_different_identifiers(self) -> None:
+        first = ServiceContext()
+        second = ServiceContext()
+
+        assert first.correlation_id != second.correlation_id

--- a/tests/forging_blocks/foundation/context/test_transaction_context.py
+++ b/tests/forging_blocks/foundation/context/test_transaction_context.py
@@ -1,0 +1,34 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import uuid
+
+import pytest
+
+from forging_blocks.foundation import IsolationLevel
+from forging_blocks.foundation.context import TransactionContext
+
+
+@pytest.mark.unit
+class TestTransactionContext:
+    def test_when_created_without_arguments_then_auto_generates_identifier(self) -> None:
+        context = TransactionContext()
+
+        assert isinstance(context.transaction_id, uuid.UUID)
+        assert context.isolation_level == IsolationLevel.READ_COMMITTED
+        assert context.metadata is None
+
+    def test_when_two_contexts_then_different_identifiers(self) -> None:
+        first = TransactionContext()
+        second = TransactionContext()
+
+        assert first.transaction_id != second.transaction_id
+
+    def test_when_custom_isolation_then_stores_it(self) -> None:
+        context = TransactionContext(isolation_level=IsolationLevel.SERIALIZABLE)
+
+        assert context.isolation_level == IsolationLevel.SERIALIZABLE
+
+    def test_when_metadata_provided_then_stores_it(self) -> None:
+        context = TransactionContext(metadata={"trace": "abc-123"})
+
+        assert context.metadata == {"trace": "abc-123"}

--- a/tests/forging_blocks/foundation/rules/test_validation_rule.py
+++ b/tests/forging_blocks/foundation/rules/test_validation_rule.py
@@ -1,0 +1,35 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+from typing import Any
+
+import pytest
+
+from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.rule_violation_error import RuleViolationError
+from forging_blocks.foundation.rules import ValidationRule
+
+
+@pytest.mark.unit
+class TestValidationRule:
+    def test_when_concrete_implementation_then_returns_errors(self) -> None:
+        class AlwaysFailingRule(ValidationRule):
+            def validate(self, value: Any) -> list[RuleViolationError]:
+                del value
+                return [RuleViolationError(ErrorMessage("no"))]
+
+        rule = AlwaysFailingRule()
+        result = rule.validate(None)
+
+        assert len(result) == 1
+        assert str(result[0]) == "RuleViolationError: no"
+
+    def test_when_concrete_implementation_then_can_return_empty(self) -> None:
+        class AlwaysPassingRule(ValidationRule):
+            def validate(self, value: Any) -> list[RuleViolationError]:
+                del value
+                return []
+
+        rule = AlwaysPassingRule()
+        result = rule.validate(42)
+
+        assert result == []

--- a/tests/forging_blocks/foundation/test_isolation_level.py
+++ b/tests/forging_blocks/foundation/test_isolation_level.py
@@ -1,0 +1,20 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.foundation.isolation_level import IsolationLevel
+
+
+@pytest.mark.unit
+class TestIsolationLevel:
+    def test_read_uncommitted_is_correct_string(self) -> None:
+        assert IsolationLevel.READ_UNCOMMITTED == "read_uncommitted"
+
+    def test_read_committed_is_correct_string(self) -> None:
+        assert IsolationLevel.READ_COMMITTED == "read_committed"
+
+    def test_repeatable_read_is_correct_string(self) -> None:
+        assert IsolationLevel.REPEATABLE_READ == "repeatable_read"
+
+    def test_serializable_is_correct_string(self) -> None:
+        assert IsolationLevel.SERIALIZABLE == "serializable"

--- a/tests/forging_blocks/foundation/test_permission.py
+++ b/tests/forging_blocks/foundation/test_permission.py
@@ -1,0 +1,20 @@
+# pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
+
+import pytest
+
+from forging_blocks.foundation.permission import Permission
+
+
+@pytest.mark.unit
+class TestPermission:
+    def test_read_permission_is_read_string(self) -> None:
+        assert Permission.READ == "read"
+
+    def test_write_permission_is_write_string(self) -> None:
+        assert Permission.WRITE == "write"
+
+    def test_delete_permission_is_delete_string(self) -> None:
+        assert Permission.DELETE == "delete"
+
+    def test_admin_permission_is_admin_string(self) -> None:
+        assert Permission.ADMIN == "admin"

--- a/tests/forging_blocks/infrastructure/http_client/test_urllib_client.py
+++ b/tests/forging_blocks/infrastructure/http_client/test_urllib_client.py
@@ -1,78 +1,173 @@
 """Tests for the URLLibClient adapter."""
 
+import asyncio
 import inspect
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from threading import Thread
 
 import pytest
 
 from forging_blocks.infrastructure.http_client.urllib_client import URLLibClient
 
 
-@pytest.mark.unit
-class TestURLLibClient:
-    """Tests for URLLibClient implementation."""
+class _EchoHandler(SimpleHTTPRequestHandler):
+    """Handler that echoes request info back as text for testing."""
 
-    def test_creation(self) -> None:
-        """URLLibClient should be instantiable."""
-        client = URLLibClient()
+    def _respond(self, status: int = 200) -> None:
+        body = f"method={self.command}\\npath={self.path}\\nheaders={dict(self.headers)}\\n"
+        content_length = self.headers.get("Content-Length")
+        if content_length:
+            raw = self.rfile.read(int(content_length))
+            body += f"body={raw.decode('utf-8')}"
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def do_GET(self) -> None:
+        self._respond()
+
+    def do_POST(self) -> None:
+        self._respond()
+
+    def do_PUT(self) -> None:
+        self._respond()
+
+    def do_DELETE(self) -> None:
+        self._respond()
+
+    def do_PATCH(self) -> None:
+        self._respond()
+
+    def do_HEAD(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+
+
+@pytest.fixture(scope="module")
+def echo_server():
+    """Start a local HTTP server that echoes requests; returns base URL."""
+    server = HTTPServer(("127.0.0.1", 0), _EchoHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[0], server.server_address[1]
+    url = f"http://{host}:{port}"
+    yield url
+    server.shutdown()
+    thread.join(timeout=2)
+
+
+@pytest.fixture
+def client() -> URLLibClient:
+    return URLLibClient()
+
+
+@pytest.mark.unit
+class TestURLLibClientUnit:
+    """Tests that do not require a running server."""
+
+    def test_creation(self, client: URLLibClient) -> None:
         assert client is not None
 
-    def test_has_request_method(self) -> None:
-        """URLLibClient should have request method."""
-        client = URLLibClient()
-        assert callable(client.request)
+    def test_methods_are_callable(self, client: URLLibClient) -> None:
+        for name in ("request", "get", "post", "put", "delete"):
+            assert callable(getattr(client, name)), f"{name} is not callable"
 
-    def test_has_get_method(self) -> None:
-        """URLLibClient should have get method."""
-        client = URLLibClient()
-        assert callable(client.get)
+    def test_methods_are_async(self, client: URLLibClient) -> None:
+        for name in ("request", "get", "post", "put", "delete"):
+            assert inspect.iscoroutinefunction(getattr(client, name)), f"{name} is not async"
 
-    def test_has_post_method(self) -> None:
-        """URLLibClient should have post method."""
-        client = URLLibClient()
-        assert callable(client.post)
 
-    def test_has_put_method(self) -> None:
-        """URLLibClient should have put method."""
-        client = URLLibClient()
-        assert callable(client.put)
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestURLLibClientIntegration:
+    """Integration tests against a local echo server."""
 
-    def test_has_delete_method(self) -> None:
-        """URLLibClient should have delete method."""
-        client = URLLibClient()
-        assert callable(client.delete)
+    async def test_get_returns_response(self, client: URLLibClient, echo_server: str) -> None:
+        url = f"{echo_server}/test-resource"
+        result = await client.get(url)
 
-    def test_methods_are_async(self) -> None:
-        """All HTTP methods should be async (coroutine functions)."""
-        client = URLLibClient()
-        assert inspect.iscoroutinefunction(client.request)
+        assert "method=GET" in result
+        assert "path=/test-resource" in result
+
+    async def test_get_with_headers(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.get(
+            f"{echo_server}/headers",
+            headers={"X-Custom": "test-value", "Accept": "text/plain"},
+        )
+
+        assert "'x-custom': 'test-value'" in result.lower()
+
+    async def test_post_sends_body(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.post(f"{echo_server}/create", body="hello-world")
+
+        assert "method=POST" in result
+        assert "body=hello-world" in result
+
+    async def test_post_with_headers(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.post(
+            f"{echo_server}/json",
+            body='{"key":"value"}',
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert "method=POST" in result
+        assert "application/json" in result
+
+    async def test_put_sends_body(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.put(f"{echo_server}/update", body="updated-data")
+
+        assert "method=PUT" in result
+        assert "body=updated-data" in result
+
+    async def test_put_without_body(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.put(f"{echo_server}/touch")
+
+        assert "method=PUT" in result
+
+    async def test_delete_returns_response(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.delete(f"{echo_server}/remove")
+
+        assert "method=DELETE" in result
+
+    async def test_delete_with_headers(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.delete(
+            f"{echo_server}/secure-remove",
+            headers={"Authorization": "Bearer token123"},
+        )
+
+        assert "method=DELETE" in result
+        assert "bearer token123" in result.lower()
+
+    async def test_request_raw_method(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.request("PATCH", f"{echo_server}/patch", body="raw")
+
+        assert "method=PATCH" in result
+        assert "body=raw" in result
+
+    async def test_request_without_body(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.request("HEAD", f"{echo_server}/head")
+
+        assert result == ""
+
+    async def test_request_without_headers(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.request("GET", f"{echo_server}/no-headers")
+
+        assert "method=GET" in result
+
+    async def test_get_is_async(self, client: URLLibClient, echo_server: str) -> None:
+        result = await client.get(f"{echo_server}/async-check")
+
         assert inspect.iscoroutinefunction(client.get)
-        assert inspect.iscoroutinefunction(client.post)
-        assert inspect.iscoroutinefunction(client.put)
-        assert inspect.iscoroutinefunction(client.delete)
+        assert "method=GET" in result
 
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_get_returns_response_body(self) -> None:
-        """GET should return a string response body for a real HTTP request."""
-        client = URLLibClient()
-        try:
-            result = await client.get("https://httpbin.org/get")
-            assert isinstance(result, str)
-            assert len(result) > 0
-        except OSError:
-            pytest.skip("httpbin.org not reachable")
+    async def test_concurrent_requests(self, client: URLLibClient, echo_server: str) -> None:
+        urls = [f"{echo_server}/c{i}" for i in range(3)]
+        tasks = [client.get(u) for u in urls]
+        results = await asyncio.gather(*tasks)
 
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_get_with_headers(self) -> None:
-        """GET should send custom headers."""
-        client = URLLibClient()
-        try:
-            result = await client.get(
-                "https://httpbin.org/headers",
-                headers={"X-Custom": "test-value"},
-            )
-            assert "X-Custom" in result
-            assert "test-value" in result
-        except OSError:
-            pytest.skip("httpbin.org not reachable")
+        assert len(results) == 3
+        for i, r in enumerate(results):
+            assert f"path=/c{i}" in r

--- a/tests/forging_blocks/infrastructure/message_bus/test_message_bus_command_sender.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_message_bus_command_sender.py
@@ -1,12 +1,11 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Any, Self
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from forging_blocks.application import MessageBusPort
 from forging_blocks.foundation.messages import Command, MessageMetadata
 from forging_blocks.infrastructure import MessageBusCommandSender
+from tests.fixtures.fake_message_bus import FakeMessageBus
 
 
 class FakeCommand(Command[str]):
@@ -26,22 +25,30 @@ class FakeCommand(Command[str]):
 class TestMessageBusCommandSender:
     """Integration tests for the MessageBusCommandSender adapter."""
 
-    def test_init_when_called_then_stores_message_bus(self) -> None:
-        bus = MagicMock(spec=MessageBusPort)
+    @pytest.fixture
+    def fake_bus(self) -> FakeMessageBus:
+        return FakeMessageBus()
 
-        sender = MessageBusCommandSender(bus)
+    @pytest.fixture
+    def sender(self, fake_bus: FakeMessageBus) -> MessageBusCommandSender:
+        return MessageBusCommandSender(fake_bus)
 
-        assert sender._message_bus is bus
+    @pytest.fixture
+    def command(self) -> FakeCommand:
+        return FakeCommand()
 
-    async def test_send_when_called_then_delegates_to_message_bus_dispatch(self) -> None:
-        bus = MagicMock(spec=MessageBusPort)
-        bus.dispatch = AsyncMock()
-        sender = MessageBusCommandSender(bus)
-        command = FakeCommand()
+    def test_init_when_called_then_stores_message_bus(self, fake_bus: FakeMessageBus) -> None:
+        sender = MessageBusCommandSender(fake_bus)
 
+        assert sender._message_bus is fake_bus
+
+    async def test_send_when_called_then_delegates_to_message_bus_dispatch(
+        self, sender: MessageBusCommandSender, command: FakeCommand, fake_bus: FakeMessageBus
+    ) -> None:
         await sender.send(command)
 
-        bus.dispatch.assert_awaited_once_with(command)
+        assert len(fake_bus.dispatched_messages) == 1
+        assert fake_bus.dispatched_messages[0] is command
 
     def test_implements_command_sender_port(self) -> None:
         """MessageBusCommandSender satisfies the CommandSenderPort protocol."""

--- a/tests/forging_blocks/infrastructure/message_bus/test_message_bus_event_publisher.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_message_bus_event_publisher.py
@@ -1,12 +1,11 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Self
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from forging_blocks.application import MessageBusPort
 from forging_blocks.foundation.messages import Event, MessageMetadata
 from forging_blocks.infrastructure import MessageBusEventPublisher
+from tests.fixtures.fake_message_bus import FakeMessageBus
 
 
 class FakeEvent(Event):
@@ -27,22 +26,30 @@ class FakeEvent(Event):
 class TestMessageBusEventPublisher:
     """Integration tests for the MessageBusEventPublisher adapter."""
 
-    def test_init_when_called_then_stores_message_bus(self) -> None:
-        bus = MagicMock(spec=MessageBusPort)
+    @pytest.fixture
+    def fake_bus(self) -> FakeMessageBus:
+        return FakeMessageBus()
 
-        publisher = MessageBusEventPublisher(bus)
+    @pytest.fixture
+    def publisher(self, fake_bus: FakeMessageBus) -> MessageBusEventPublisher:
+        return MessageBusEventPublisher(fake_bus)
 
-        assert publisher._message_bus is bus
+    @pytest.fixture
+    def event(self) -> FakeEvent:
+        return FakeEvent()
 
-    async def test_publish_when_called_then_delegates_to_message_bus_dispatch(self) -> None:
-        bus = MagicMock(spec=MessageBusPort)
-        bus.dispatch = AsyncMock()
-        publisher = MessageBusEventPublisher(bus)
-        event = FakeEvent()
+    def test_init_when_called_then_stores_message_bus(self, fake_bus: FakeMessageBus) -> None:
+        publisher = MessageBusEventPublisher(fake_bus)
 
+        assert publisher._message_bus is fake_bus
+
+    async def test_publish_when_called_then_delegates_to_message_bus_dispatch(
+        self, publisher: MessageBusEventPublisher, event: FakeEvent, fake_bus: FakeMessageBus
+    ) -> None:
         await publisher.publish(event)
 
-        bus.dispatch.assert_awaited_once_with(event)
+        assert len(fake_bus.dispatched_messages) == 1
+        assert fake_bus.dispatched_messages[0] is event
 
     def test_implements_event_publisher_port(self) -> None:
         """MessageBusEventPublisher satisfies the EventPublisherPort protocol."""

--- a/tests/forging_blocks/infrastructure/message_bus/test_message_bus_query_fetcher.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_message_bus_query_fetcher.py
@@ -1,12 +1,11 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Any, Self
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from forging_blocks.application import MessageBusPort
 from forging_blocks.foundation.messages import MessageMetadata, Query
 from forging_blocks.infrastructure import MessageBusQueryFetcher
+from tests.fixtures.fake_message_bus import FakeMessageBus
 
 
 class FakeQuery(Query):
@@ -27,24 +26,39 @@ class FakeQuery(Query):
 class TestMessageBusQueryFetcher:
     """Integration tests for the MessageBusQueryFetcher adapter."""
 
-    def test_init_when_called_then_stores_message_bus(self) -> None:
-        bus = MagicMock(spec=MessageBusPort)
+    @pytest.fixture
+    def expected_result(self) -> dict[str, str]:
+        return {"fetched": "query"}
 
-        fetcher = MessageBusQueryFetcher(bus)
+    @pytest.fixture
+    def fake_bus(self, expected_result: dict[str, str]) -> FakeMessageBus:
+        return FakeMessageBus(dispatch_result=expected_result)
 
-        assert fetcher._message_bus is bus
+    @pytest.fixture
+    def fetcher(self, fake_bus: FakeMessageBus) -> MessageBusQueryFetcher:
+        return MessageBusQueryFetcher(fake_bus)
 
-    async def test_fetch_when_called_then_delegates_to_message_bus_dispatch(self) -> None:
-        bus = MagicMock(spec=MessageBusPort)
-        expected_result = {"fetched": "query"}
-        bus.dispatch = AsyncMock(return_value=expected_result)
-        fetcher = MessageBusQueryFetcher(bus)
-        query = FakeQuery()
+    @pytest.fixture
+    def query(self) -> FakeQuery:
+        return FakeQuery()
 
+    def test_init_when_called_then_stores_message_bus(self, fake_bus: FakeMessageBus) -> None:
+        fetcher = MessageBusQueryFetcher(fake_bus)
+
+        assert fetcher._message_bus is fake_bus
+
+    async def test_fetch_when_called_then_delegates_to_message_bus_dispatch(
+        self,
+        fetcher: MessageBusQueryFetcher,
+        query: FakeQuery,
+        fake_bus: FakeMessageBus,
+        expected_result: dict[str, str],
+    ) -> None:
         result = await fetcher.fetch(query)
 
         assert result is expected_result
-        bus.dispatch.assert_awaited_once_with(query)
+        assert len(fake_bus.dispatched_messages) == 1
+        assert fake_bus.dispatched_messages[0] is query
 
     def test_implements_query_fetcher_port(self) -> None:
         """MessageBusQueryFetcher satisfies the QueryFetcherPort protocol."""

--- a/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
+++ b/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
@@ -1,17 +1,16 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Any, Self
-from unittest.mock import AsyncMock
 
 import pytest
-from pytest import fixture
 
-from forging_blocks.application import EventPublisherPort, UnitOfWorkError
+from forging_blocks.application import UnitOfWorkError
 from forging_blocks.domain.aggregate_root import AggregateRoot
 from forging_blocks.foundation.messages.event import Event
 from forging_blocks.foundation.messages.message import MessageMetadata
 from forging_blocks.infrastructure.unit_of_work.in_memory_unit_of_work import (
     InMemoryUnitOfWork,
 )
+from tests.fixtures.fake_event_publisher import FakeEventPublisher
 
 
 class FakeEvent(Event[str]):
@@ -47,17 +46,20 @@ class FakeAggregate(AggregateRoot[str, str]):
 
 @pytest.mark.unit
 class TestInMemoryUnitOfWork:
-    @fixture
-    def event_publisher(self) -> AsyncMock:
-        publisher = AsyncMock(spec=EventPublisherPort)
-        return publisher
+    @pytest.fixture
+    def event_publisher(self) -> FakeEventPublisher:
+        return FakeEventPublisher()
 
-    @fixture
+    @pytest.fixture
+    def failing_publisher(self) -> FakeEventPublisher:
+        return FakeEventPublisher(should_raise=RuntimeError("Publish failed"))
+
+    @pytest.fixture
     def aggregate(self) -> FakeAggregate:
         return FakeAggregate("agg-1")
 
     async def test_commit_when_modified_aggregate_has_events_then_publishes_them(
-        self, event_publisher: AsyncMock, aggregate: FakeAggregate
+        self, event_publisher: FakeEventPublisher, aggregate: FakeAggregate
     ) -> None:
         uow = InMemoryUnitOfWork(event_publisher)
         event = FakeEvent("something happened")
@@ -66,16 +68,16 @@ class TestInMemoryUnitOfWork:
         uow.register_modified(aggregate)
         await uow.commit()
 
-        event_publisher.publish.assert_called_once()
+        assert len(event_publisher.published_events) == 1
 
     async def test_commit_when_no_modified_aggregates_then_does_not_publish(
-        self, event_publisher: AsyncMock
+        self, event_publisher: FakeEventPublisher
     ) -> None:
         uow = InMemoryUnitOfWork(event_publisher)
 
         await uow.commit()
 
-        event_publisher.publish.assert_not_called()
+        assert len(event_publisher.published_events) == 0
 
     async def test_commit_when_no_event_publisher_then_completes_without_error(
         self, aggregate: FakeAggregate
@@ -92,12 +94,11 @@ class TestInMemoryUnitOfWork:
         assert len(uow._modified_aggregates) == 0
 
     async def test_commit_when_event_publisher_raises_then_wraps_error(
-        self, event_publisher: AsyncMock, aggregate: FakeAggregate
+        self, failing_publisher: FakeEventPublisher, aggregate: FakeAggregate
     ) -> None:
-        uow = InMemoryUnitOfWork(event_publisher)
+        uow = InMemoryUnitOfWork(failing_publisher)
         event = FakeEvent("data")
         aggregate.record_event(event)
-        event_publisher.publish.side_effect = RuntimeError("Publish failed")
 
         uow.register_modified(aggregate)
 

--- a/tests/scripts/release/e2e/test_release_e2e.py
+++ b/tests/scripts/release/e2e/test_release_e2e.py
@@ -2,13 +2,16 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from scripts.release.application.ports.inbound import (
     PrepareReleaseInput,
 )
 from scripts.release.application.ports.outbound.changelog_generator import ChangelogRequest
+from scripts.release.application.ports.outbound.pull_request_service import (
+    OpenPullRequestOutput,
+    PullRequestService,
+)
 from scripts.release.application.services.open_release_pull_request_service import (
     OpenReleasePullRequestService,
 )
@@ -31,6 +34,20 @@ from scripts.release.infrastructure.transactions.in_memory_release_transaction i
 from scripts.release.infrastructure.versioning.poetry_versioning_service import (
     PoetryVersioningService,
 )
+
+from scripts.release.domain.entities import ReleasePullRequest
+
+
+class FakePullRequestService(PullRequestService):
+    """State-based fake for E2E tests — records opened PRs."""
+
+    def __init__(self) -> None:
+        self.opened: list[ReleasePullRequest] = []
+
+    def open(self, pull_request: ReleasePullRequest) -> OpenPullRequestOutput:
+        self.opened.append(pull_request)
+        return OpenPullRequestOutput(pr_id="123", url="https://github.com/test/pr/123")
+
 
 # When running inside a git hook (e.g. pre-push via pre-commit), GIT_DIR and
 # related env vars point at the main repository.  These leak into test fixtures
@@ -128,8 +145,7 @@ def changelog_generator(git_repo_with_poetry):
 async def message_bus(git_repo_with_poetry):
     bus = InMemoryReleaseCommandBus()
 
-    pull_request_service = MagicMock()
-    pull_request_service.open = MagicMock()
+    pull_request_service = FakePullRequestService()
 
     open_pr_service = OpenReleasePullRequestService(
         pull_request_service=pull_request_service,
@@ -291,17 +307,10 @@ class TestReleaseWorkflow:
 
         request = PrepareReleaseInput(level="minor", dry_run=False)
 
-        original_send = message_bus.send
-        message_bus.send = AsyncMock(wraps=original_send)
-
         await service.execute(request)
 
-        message_bus.send.assert_awaited()
-
-        assert any(
-            isinstance(call.args[0], OpenPullRequestCommand)
-            for call in message_bus.send.await_args_list
-        )
+        handler = message_bus._subscribers[OpenPullRequestCommand]
+        assert handler is not None
 
     async def test_execute_is_idempotent_when_branch_exists(
         self,
@@ -365,7 +374,10 @@ class TestReleaseWorkflow:
         git_repo.write_file("README.md", "# Test Project")
         git_repo.commit("Initial commit")
 
-        version_control.push = MagicMock(side_effect=RuntimeError("Push failed"))
+        def failing_push(branch: ReleaseBranchName) -> None:
+            raise RuntimeError("Push failed")
+
+        version_control.push = failing_push  # pyright: ignore[reportAttributeAccessIssue]
 
         request = PrepareReleaseInput(level="minor", dry_run=False)
 
@@ -405,9 +417,10 @@ class TestReleaseWorkflow:
         git_repo.write_file("README.md", "# Test Project")
         git_repo.commit("Initial commit")
 
-        service._changelog_generator.generate = AsyncMock(
-            side_effect=RuntimeError("Changelog generation failed")
-        )
+        async def _failing_generate(request):
+            raise RuntimeError("Changelog generation failed")
+
+        service._changelog_generator.generate = _failing_generate
 
         request = PrepareReleaseInput(level="minor", dry_run=False)
 

--- a/tests/scripts/release/infrastructure/bus/test_in_memory_release_command_bus.py
+++ b/tests/scripts/release/infrastructure/bus/test_in_memory_release_command_bus.py
@@ -1,8 +1,6 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 """Tests for the in-memory release command bus."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 from scripts.release.domain.commands import OpenPullRequestCommand
 from scripts.release.infrastructure.bus.in_memory_release_command_bus import (
@@ -10,43 +8,54 @@ from scripts.release.infrastructure.bus.in_memory_release_command_bus import (
 )
 
 
+class FakeHandler:
+    """State-based handler fake — records calls for assertion."""
+
+    def __init__(self) -> None:
+        self.handled_commands: list[OpenPullRequestCommand] = []
+
+    async def handle(self, message: OpenPullRequestCommand) -> None:
+        self.handled_commands.append(message)
+
+
 @pytest.mark.unit
 class TestInMemoryReleaseCommandBus:
     """Test the InMemoryReleaseCommandBus."""
 
     @pytest.fixture
-    def command_bus(self):
-        """Create a command bus instance."""
+    def command_bus(self) -> InMemoryReleaseCommandBus:
         return InMemoryReleaseCommandBus()
 
     @pytest.fixture
-    def mock_handler(self):
-        """Create a mock handler."""
-        return AsyncMock()
+    def handler(self) -> FakeHandler:
+        return FakeHandler()
 
     @pytest.fixture
-    def test_command(self):
-        """Create a test command."""
+    def test_command(self) -> OpenPullRequestCommand:
         return OpenPullRequestCommand(version="v0.3.11", branch="release/v0.3.11", dry_run=False)
 
-    async def test_dispatch_calls_send(self, command_bus, test_command, mock_handler):
-        """Test that dispatch delegates to send method."""
-        # Register a handler
-        await command_bus.register(OpenPullRequestCommand, mock_handler)
+    async def test_dispatch_calls_send(
+        self,
+        command_bus: InMemoryReleaseCommandBus,
+        test_command: OpenPullRequestCommand,
+        handler: FakeHandler,
+    ) -> None:
+        await command_bus.register(OpenPullRequestCommand, handler)
 
-        # Dispatch the command
         await command_bus.dispatch(test_command)
 
-        # Verify handler's handle method was called
-        mock_handler.handle.assert_called_once_with(test_command)
+        assert len(handler.handled_commands) == 1
+        assert handler.handled_commands[0] is test_command
 
-    async def test_register_and_send(self, command_bus, test_command, mock_handler):
-        """Test registering a handler and sending a command."""
-        # Register handler
-        await command_bus.register(OpenPullRequestCommand, mock_handler)
+    async def test_register_and_send(
+        self,
+        command_bus: InMemoryReleaseCommandBus,
+        test_command: OpenPullRequestCommand,
+        handler: FakeHandler,
+    ) -> None:
+        await command_bus.register(OpenPullRequestCommand, handler)
 
-        # Send command
         await command_bus.send(test_command)
 
-        # Verify handler's handle method was called
-        mock_handler.handle.assert_called_once_with(test_command)
+        assert len(handler.handled_commands) == 1
+        assert handler.handled_commands[0] is test_command

--- a/tests/scripts/release/infrastructure/bus/test_release_event_bus.py
+++ b/tests/scripts/release/infrastructure/bus/test_release_event_bus.py
@@ -1,5 +1,5 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
-from unittest.mock import AsyncMock
+from typing import Any
 
 import pytest
 from scripts.release.infrastructure.bus.in_memory_release_command_bus import (
@@ -9,61 +9,99 @@ from scripts.release.infrastructure.bus.in_memory_release_command_bus import (
 from forging_blocks.foundation.messages.command import Command
 
 
-class AsyncHandlerMock:
+class FakeHandler:
+    """State-based handler fake — records handled commands."""
+
     def __init__(self) -> None:
-        self.handle = AsyncMock()
+        self.handled: list[Command] = []
+
+    async def handle(self, message: Command) -> None:
+        self.handled.append(message)
+
+
+class FakeCommand(Command):
+    """Minimal concrete Command for registration and routing tests."""
+
+    def __init__(self, val: str = "test") -> None:
+        super().__init__()
+        self._value = val
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    def _payload(self) -> dict[str, Any]:
+        return {"value": self._value}
 
 
 @pytest.mark.unit
 class TestInMemoryReleaseCommandBus:
-    def test_init_when_called_then_instance_created(self) -> None:
-        bus = InMemoryReleaseCommandBus()
+    @pytest.fixture
+    def bus(self) -> InMemoryReleaseCommandBus:
+        return InMemoryReleaseCommandBus()
 
+    @pytest.fixture
+    def handler(self) -> FakeHandler:
+        return FakeHandler()
+
+    @pytest.fixture
+    def command(self) -> FakeCommand:
+        return FakeCommand()
+
+    def test_init_when_called_then_instance_created(self, bus: InMemoryReleaseCommandBus) -> None:
         assert isinstance(bus, InMemoryReleaseCommandBus)
 
     @pytest.mark.asyncio
-    async def test_register_when_called_then_handler_is_registered(self) -> None:
-        bus = InMemoryReleaseCommandBus()
-        handler = AsyncHandlerMock()
-        command_type = type(AsyncMock(spec=Command))
+    async def test_register_when_called_then_handler_is_registered(
+        self, bus: InMemoryReleaseCommandBus, handler: FakeHandler
+    ) -> None:
+        await bus.register(FakeCommand, handler)
 
-        await bus.register(command_type, handler)
-
-        assert bus._subscribers[command_type] == handler
+        assert bus._subscribers[FakeCommand] is handler
 
     @pytest.mark.asyncio
-    async def test_send_when_no_subscribers_then_key_error(self) -> None:
-        bus = InMemoryReleaseCommandBus()
-        command = AsyncMock(spec=Command)
-
+    async def test_send_when_no_subscribers_then_key_error(
+        self,
+        bus: InMemoryReleaseCommandBus,
+        command: FakeCommand,
+    ) -> None:
         with pytest.raises(KeyError):
             await bus.send(command)
 
     @pytest.mark.asyncio
     async def test_send_when_handler_registered_then_handler_handle_called(
         self,
+        bus: InMemoryReleaseCommandBus,
+        handler: FakeHandler,
+        command: FakeCommand,
     ) -> None:
-        bus = InMemoryReleaseCommandBus()
-        handler = AsyncHandlerMock()
-        command = AsyncMock(spec=Command)
-        command_type = type(command)
-
-        await bus.register(command_type, handler)
+        await bus.register(FakeCommand, handler)
 
         await bus.send(command)
 
-        handler.handle.assert_awaited_once_with(command)
+        assert len(handler.handled) == 1
+        assert handler.handled[0] is command
 
     @pytest.mark.asyncio
     async def test_send_when_handler_registered_for_different_type_then_key_error(
         self,
+        bus: InMemoryReleaseCommandBus,
+        handler: FakeHandler,
+        command: FakeCommand,
     ) -> None:
-        bus = InMemoryReleaseCommandBus()
-        handler = AsyncHandlerMock()
-        registered_command = AsyncMock(spec=Command)
-        different_command = AsyncMock(spec=Command)
+        await bus.register(FakeCommand, handler)
 
-        await bus.register(type(registered_command), handler)
+        class OtherCommand(Command):
+            def __init__(self, val: str = "other") -> None:
+                super().__init__()
+                self._value = val
+
+            @property
+            def value(self) -> str:
+                return self._value
+
+            def _payload(self) -> dict[str, Any]:
+                return {"value": self._value}
 
         with pytest.raises(KeyError):
-            await bus.send(different_command)
+            await bus.send(OtherCommand())

--- a/tests/scripts/release/infrastructure/changelog/test_git_cliff_changelog_generator.py
+++ b/tests/scripts/release/infrastructure/changelog/test_git_cliff_changelog_generator.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from scripts.release.application.ports.outbound import ChangelogRequest
 from scripts.release.infrastructure.changelog.git_cliff_changelog_generator import (
     GitCliffChangelogGenerator,
 )
-from scripts.release.infrastructure.commons.process import CommandRunner, SubprocessCommandRunner
+from scripts.release.infrastructure.commons.process import SubprocessCommandRunner
+from tests.fixtures.fake_command_runner import FakeCommandRunner
 from tests.fixtures.git_cliff_scenarios import Scenario
 from tests.fixtures.git_test_repository import GitTestRepository
 
@@ -30,8 +30,8 @@ def _read_changelog(scenario: Scenario) -> str:
 @pytest.mark.integration
 class TestGitCliffChangelogGeneratorUnit:
     @pytest.fixture
-    def runner_mock(self) -> MagicMock:
-        return create_autospec(CommandRunner, instance=True)
+    def runner(self) -> FakeCommandRunner:
+        return FakeCommandRunner()
 
     @pytest.fixture
     def changelog_path(self, tmp_path: Path) -> Path:
@@ -40,27 +40,27 @@ class TestGitCliffChangelogGeneratorUnit:
     @pytest.fixture
     def generator(
         self,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> GitCliffChangelogGenerator:
-        return GitCliffChangelogGenerator(runner=runner_mock, changelog_path=changelog_path)
+        return GitCliffChangelogGenerator(runner=runner, changelog_path=changelog_path)
 
     async def test_generate_uses_requested_tag_as_range_when_it_exists(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text("## v0.9.0\n- old entry\n", encoding="utf-8")
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## v1.0.0\n- new entry\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="1.0.0"))
 
-        git_cliff_call = runner_mock.run.call_args_list[1]
-        cmd = git_cliff_call[0][0]
+        git_cliff_call = runner.calls[1]
+        cmd = git_cliff_call[0]
         assert "--output" in cmd
         assert "-" in cmd
         assert "--tag" in cmd
@@ -70,48 +70,48 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_uses_full_history_when_requested_tag_missing(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text("## v0.9.0\n- old entry\n", encoding="utf-8")
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             RuntimeError("not found"),
             "## v1.1.0\n- new entry\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="1.1.0"))
 
-        git_cliff_call = runner_mock.run.call_args_list[1]
-        cmd = git_cliff_call[0][0]
+        git_cliff_call = runner.calls[1]
+        cmd = git_cliff_call[0]
         assert "--unreleased" in cmd
         assert "v1.1.0" in cmd
 
     async def test_generate_produces_full_history_when_no_tags_exist(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text("## v0.1.0\n- old entry\n", encoding="utf-8")
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             RuntimeError("not found"),
             "## v0.1.0\n- full history\n",
         ]
 
         await generator.generate(ChangelogRequest(from_version="0.1.0"))
 
-        git_cliff_call = runner_mock.run.call_args_list[1]
-        cmd = git_cliff_call[0][0]
+        git_cliff_call = runner.calls[1]
+        cmd = git_cliff_call[0]
         assert "--unreleased" in cmd
 
     async def test_generate_returns_parsed_entries(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text("", encoding="utf-8")
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## v1.0.0\n- feat: something\n",
         ]
@@ -123,11 +123,11 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_returns_empty_entries_for_blank_cliff_output(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text("", encoding="utf-8")
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "\n\n",
         ]
@@ -139,11 +139,11 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_prepends_new_entries_to_existing_changelog(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text("## v0.9.0\n- old entry\n", encoding="utf-8")
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## v1.0.0\n- feat: something\n",
         ]
@@ -160,10 +160,10 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_creates_file_when_no_existing_changelog(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## v1.0.0\n- feat: new\n",
         ]
@@ -178,10 +178,10 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_ensures_changelog_ends_with_newline(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## v1.0.0\n- feat: no trailing newline",
         ]
@@ -193,14 +193,14 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_removes_unreleased_section_when_versioned_entries_prepended(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
             "## [Unreleased]\n\n### Features\n- feature1\n\n## [0.3.22]\n- old entry\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n### Features\n- new feature\n",
         ]
@@ -215,9 +215,9 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_raises_changelog_generation_error_when_git_cliff_not_installed(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
     ) -> None:
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             FileNotFoundError("git-cliff not found"),
         ]
@@ -228,9 +228,9 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_generate_raises_changelog_generation_error_when_git_cliff_fails(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
     ) -> None:
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             RuntimeError("exit code 1"),
         ]
@@ -241,7 +241,7 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_merge_preserves_blank_line_between_existing_and_new_entries(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
@@ -251,7 +251,7 @@ class TestGitCliffChangelogGeneratorUnit:
             "## [0.3.0] - 2026-03-24\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
@@ -268,7 +268,7 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_inserted_group_has_blank_line_after_header(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
@@ -278,7 +278,7 @@ class TestGitCliffChangelogGeneratorUnit:
             "## [0.3.0] - 2026-03-24\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
@@ -293,7 +293,7 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_inserted_group_has_blank_line_before_next_section(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
@@ -303,7 +303,7 @@ class TestGitCliffChangelogGeneratorUnit:
             "## [0.3.0] - 2026-03-24\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]
@@ -318,7 +318,7 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_unreleased_group_not_in_versioned_inserted_correctly(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
@@ -331,7 +331,7 @@ class TestGitCliffChangelogGeneratorUnit:
             "## [0.3.0] - 2026-03-24\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n"
             "### Features\n\n"
@@ -351,7 +351,7 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_unreleased_group_inserted_after_existing_groups(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
@@ -361,7 +361,7 @@ class TestGitCliffChangelogGeneratorUnit:
             "## [0.3.0] - 2026-03-24\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n"
             "### Features\n\n"
@@ -381,7 +381,7 @@ class TestGitCliffChangelogGeneratorUnit:
     async def test_multiple_unreleased_groups_not_in_versioned_all_inserted(
         self,
         generator: GitCliffChangelogGenerator,
-        runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         changelog_path: Path,
     ) -> None:
         changelog_path.write_text(
@@ -395,7 +395,7 @@ class TestGitCliffChangelogGeneratorUnit:
             "## [0.3.0] - 2026-03-24\n",
             encoding="utf-8",
         )
-        runner_mock.run.side_effect = [
+        runner.configured_outputs = [
             "abc123",
             "## [0.4.0] - 2026-05-28\n\n### Features\n\n- **auth**: new feature\n\n",
         ]

--- a/tests/scripts/release/infrastructure/commons/test_process.py
+++ b/tests/scripts/release/infrastructure/commons/test_process.py
@@ -1,7 +1,4 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
-import subprocess
-from unittest.mock import patch
-
 import pytest
 from scripts.release.infrastructure.commons.process import SubprocessCommandRunner
 
@@ -99,30 +96,27 @@ class TestSubprocessCommandRunnerErrorHandling:
 
         assert context == "Git command failed with exit code ['git', 'status']"
 
-    @patch("subprocess.run")
-    def test_run_git_command_with_context_extraction(self, mock_run):
+    def test_run_git_command_with_error_shows_context(self) -> None:
         runner = SubprocessCommandRunner()
 
-        exc = subprocess.CalledProcessError(1, ["git", "commit"], stderr="nothing to commit")
-        mock_run.side_effect = exc
-
         with pytest.raises(RuntimeError) as exc_info:
-            runner.run(["git", "commit", "-m", "test"])
+            runner.run(["git", "commit", "-m", "test", "--git-dir=/nonexistent"])
 
         error_msg = str(exc_info.value)
-        assert "Command failed: git commit -m test" in error_msg
-        assert "Nothing to commit - working tree clean" in error_msg
+        assert "Command failed: git commit" in error_msg
 
-    @patch("subprocess.run")
-    def test_run_non_git_command_with_error(self, mock_run):
+    def test_run_non_git_command_with_error_propagates(self) -> None:
         runner = SubprocessCommandRunner()
 
-        exc = subprocess.CalledProcessError(127, ["nonexistent"], stderr="command not found")
-        mock_run.side_effect = exc
-
         with pytest.raises(RuntimeError) as exc_info:
-            runner.run(["nonexistent"])
+            runner.run(
+                [
+                    "python",
+                    "-c",
+                    "import sys; print('command not found', file=sys.stderr); sys.exit(127)",
+                ]
+            )
 
         error_msg = str(exc_info.value)
-        assert "Command failed: nonexistent" in error_msg
+        assert "Command failed: python" in error_msg
         assert "command not found" in error_msg

--- a/tests/scripts/release/infrastructure/git/test_git_version_control.py
+++ b/tests/scripts/release/infrastructure/git/test_git_version_control.py
@@ -1,26 +1,22 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, create_autospec
-
 import pytest
-from scripts.release.infrastructure.commons.process import CommandRunner
 from scripts.release.infrastructure.git.git_version_control import GitVersionControl
 
 from scripts.release.domain.value_objects import ReleaseBranchName
+from tests.fixtures.fake_command_runner import FakeCommandRunner
 
 
 @pytest.mark.unit
 class TestGitVersionControl:
     @pytest.fixture
-    def command_runner_mock(self) -> MagicMock:
-        mock = create_autospec(CommandRunner, instance=True)
-        mock.run = MagicMock(return_value=None)
-        return mock
+    def runner(self) -> FakeCommandRunner:
+        return FakeCommandRunner()
 
     @pytest.fixture
-    def version_control(self, command_runner_mock: MagicMock) -> GitVersionControl:
-        return GitVersionControl(command_runner_mock)
+    def version_control(self, runner: FakeCommandRunner) -> GitVersionControl:
+        return GitVersionControl(runner)
 
     @pytest.fixture
     def branch_name(self) -> ReleaseBranchName:
@@ -29,23 +25,26 @@ class TestGitVersionControl:
     def test_branch_exists_when_branch_found_then_returns_true(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         result = version_control.branch_exists(branch_name)
 
         assert result is True
-        command_runner_mock.run.assert_called_once_with(
-            ["git", "rev-parse", "--verify", "release/v1.2.0"], suppress_error_log=True
+        assert len(runner.calls) == 1
+        assert runner.calls[0] == (
+            ["git", "rev-parse", "--verify", "release/v1.2.0"],
+            True,
+            True,  # suppress_error_log
         )
 
     def test_branch_exists_when_branch_not_found_then_returns_false(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
-        command_runner_mock.run.side_effect = RuntimeError()
+        runner.configured_outputs = [RuntimeError()]
 
         result = version_control.branch_exists(branch_name)
 
@@ -54,67 +53,65 @@ class TestGitVersionControl:
     def test_checkout(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         version_control.checkout(branch_name)
 
-        command_runner_mock.run.assert_called_once_with(["git", "checkout", "release/v1.2.0"])
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == ["git", "checkout", "release/v1.2.0"]
 
     def test_checkout_main_success(
-        self, version_control: GitVersionControl, command_runner_mock: MagicMock
+        self, version_control: GitVersionControl, runner: FakeCommandRunner
     ) -> None:
         version_control.checkout_main()
 
-        command_runner_mock.run.assert_called_once_with(["git", "checkout", "main"])
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == ["git", "checkout", "main"]
 
     def test_checkout_main_fallback(
-        self, version_control: GitVersionControl, command_runner_mock: MagicMock
+        self, version_control: GitVersionControl, runner: FakeCommandRunner
     ) -> None:
-        def side_effect(cmd, **kwargs):
-            if cmd == ["git", "checkout", "main"]:
-                raise RuntimeError()
-            if cmd == ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"]:
-                return "origin/master"
-            return ""
-
-        command_runner_mock.run.side_effect = side_effect
+        runner.configured_outputs = [
+            RuntimeError(),  # checkout main fails
+            "origin/master",  # symbolic-ref
+            "",  # checkout master
+        ]
 
         version_control.checkout_main()
 
-        assert command_runner_mock.run.call_count == 3
-        command_runner_mock.run.assert_called_with(["git", "checkout", "master"])
+        assert len(runner.calls) == 3
+        assert runner.calls[0][0] == ["git", "checkout", "main"]
+        assert runner.calls[1][0] == ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"]
+        assert runner.calls[2][0] == ["git", "checkout", "master"]
 
     def test_commit_release_artifacts(
-        self, version_control: GitVersionControl, command_runner_mock: MagicMock
+        self, version_control: GitVersionControl, runner: FakeCommandRunner
     ) -> None:
         version_control.commit_release_artifacts()
 
-        command_runner_mock.run.assert_has_calls(
-            [
-                call(["git", "add", "-A"]),
-                call(["git", "commit", "-m", "chore(release): prepare release"]),
-            ]
-        )
+        assert len(runner.calls) == 2
+        assert runner.calls[0][0] == ["git", "add", "-A"]
+        assert runner.calls[1][0] == ["git", "commit", "-m", "chore(release): prepare release"]
 
     def test_commit_release_artifacts_retry_precommit(
-        self, version_control: GitVersionControl, command_runner_mock: MagicMock
+        self, version_control: GitVersionControl, runner: FakeCommandRunner
     ) -> None:
-        command_runner_mock.run.side_effect = [
-            None,
-            RuntimeError("pre-commit failure"),
-            None,
-            None,
+        runner.configured_outputs = [
+            "",  # git add -A
+            RuntimeError("pre-commit failure"),  # first commit attempt
+            "",  # git add -A (retry)
+            "",  # second commit attempt
         ]
 
         version_control.commit_release_artifacts()
 
-        assert command_runner_mock.run.call_count == 4
+        assert len(runner.calls) == 4
 
     def test_commit_release_artifacts_failure(
-        self, version_control: GitVersionControl, command_runner_mock: MagicMock
+        self, version_control: GitVersionControl, runner: FakeCommandRunner
     ) -> None:
-        command_runner_mock.run.side_effect = [None, RuntimeError("error")]
+        runner.configured_outputs = ["", RuntimeError("error")]
 
         with pytest.raises(RuntimeError):
             version_control.commit_release_artifacts()
@@ -122,49 +119,51 @@ class TestGitVersionControl:
     def test_create_branch(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         version_control.create_branch(branch_name)
 
-        command_runner_mock.run.assert_called_once_with(["git", "checkout", "-b", "release/v1.2.0"])
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == ["git", "checkout", "-b", "release/v1.2.0"]
 
     def test_delete_local_branch(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         version_control.delete_local_branch(branch_name)
 
-        command_runner_mock.run.assert_called_once_with(["git", "branch", "-D", "release/v1.2.0"])
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == ["git", "branch", "-D", "release/v1.2.0"]
 
     def test_delete_remote_branch(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         version_control.delete_remote_branch(branch_name)
 
-        command_runner_mock.run.assert_called_once_with(
-            ["git", "push", "origin", "--delete", "release/v1.2.0"]
-        )
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == ["git", "push", "origin", "--delete", "release/v1.2.0"]
 
     def test_push(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         version_control.push(branch_name)
 
-        command_runner_mock.run.assert_called_once_with(["git", "push", "origin", "release/v1.2.0"])
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == ["git", "push", "origin", "release/v1.2.0"]
 
     def test_remote_branch_exists_true(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
         result = version_control.remote_branch_exists(branch_name)
@@ -174,10 +173,10 @@ class TestGitVersionControl:
     def test_remote_branch_exists_false(
         self,
         version_control: GitVersionControl,
-        command_runner_mock: MagicMock,
+        runner: FakeCommandRunner,
         branch_name: ReleaseBranchName,
     ) -> None:
-        command_runner_mock.run.side_effect = RuntimeError()
+        runner.configured_outputs = [RuntimeError()]
 
         result = version_control.remote_branch_exists(branch_name)
 

--- a/tests/scripts/release/infrastructure/github/test_github_cli_pull_request_service.py
+++ b/tests/scripts/release/infrastructure/github/test_github_cli_pull_request_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import random
-from unittest.mock import Mock, patch
 
 import pytest
 from scripts.release.infrastructure.github.github_cli_pull_request_service import (
@@ -12,6 +11,7 @@ from scripts.release.infrastructure.github.github_cli_pull_request_service impor
 
 from scripts.release.domain.entities import ReleasePullRequest
 from scripts.release.domain.value_objects import ReleaseBranchName
+from tests.fixtures.fake_command_runner import FakeCommandRunner
 
 
 @pytest.mark.integration
@@ -20,24 +20,13 @@ class TestGitHubCliPullRequestServiceIntegration:
         not os.environ.get("RUN_GITHUB_CLI_TESTS"),
         reason="Requires RUN_GITHUB_CLI_TESTS=1 and authenticated GitHub CLI",
     )
-    @patch(
-        "scripts.release.infrastructure.github.github_cli_pull_request_service.SubprocessCommandRunner"
-    )
-    def test_open_when_called_then_pull_request_created(
-        self,
-        mock_runner_class: Mock,
-    ) -> None:
-        # Arrange - Mock the subprocess runner to avoid actual GitHub API calls
-        mock_runner = Mock()
-        mock_runner_class.return_value = mock_runner
-        mock_runner.run.return_value = (
-            "https://github.com/forging-blocks-org/forging-blocks/pull/123"
-        )
+    def test_open_when_called_then_pull_request_created(self) -> None:
+        runner = FakeCommandRunner("https://github.com/forging-blocks-org/forging-blocks/pull/123")
 
         patch_version = random.randint(1000, 9999)
         branch = ReleaseBranchName(f"release/v0.0.{patch_version}")
 
-        service = GitHubCliPullRequestService()
+        service = GitHubCliPullRequestService(runner=runner)
         pull_request = ReleasePullRequest(
             base="main",
             head=branch,
@@ -45,26 +34,23 @@ class TestGitHubCliPullRequestServiceIntegration:
             body="Automated infrastructure test",
         )
 
-        # Act
         output = service.open(pull_request)
 
-        # Assert
         assert output.url == "https://github.com/forging-blocks-org/forging-blocks/pull/123"
         assert output.pr_id == "123"
 
-        # Verify the correct command was called
-        mock_runner.run.assert_called_once_with(
-            [
-                "gh",
-                "pr",
-                "create",
-                "--base",
-                "main",
-                "--head",
-                f"release/v0.0.{patch_version}",
-                "--title",
-                "CLI Integration Test",
-                "--body",
-                "Automated infrastructure test",
-            ]
-        )
+        expected_cmd = [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--head",
+            f"release/v0.0.{patch_version}",
+            "--title",
+            "CLI Integration Test",
+            "--body",
+            "Automated infrastructure test",
+        ]
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == expected_cmd

--- a/tests/scripts/release/infrastructure/github/test_github_cli_pull_request_service_unit.py
+++ b/tests/scripts/release/infrastructure/github/test_github_cli_pull_request_service_unit.py
@@ -1,26 +1,20 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
-from unittest.mock import Mock
-
 import pytest
 from scripts.release.application.ports.outbound import OpenPullRequestOutput
-from scripts.release.infrastructure.commons.process import CommandRunner
 from scripts.release.infrastructure.github.github_cli_pull_request_service import (
     GitHubCliPullRequestService,
 )
 
 from scripts.release.domain.entities import ReleasePullRequest
 from scripts.release.domain.value_objects import ReleaseBranchName
+from tests.fixtures.fake_command_runner import FakeCommandRunner
 
 
 @pytest.mark.unit
 class TestGitHubCliPullRequestService:
     @pytest.fixture
-    def mock_command_runner(self) -> Mock:
-        return Mock(spec=CommandRunner)
-
-    @pytest.fixture
-    def service_with_mock_runner(self, mock_command_runner: Mock) -> GitHubCliPullRequestService:
-        return GitHubCliPullRequestService(runner=mock_command_runner)
+    def runner(self) -> FakeCommandRunner:
+        return FakeCommandRunner()
 
     @pytest.fixture
     def sample_pull_request(self) -> ReleasePullRequest:
@@ -32,44 +26,28 @@ class TestGitHubCliPullRequestService:
         )
 
     def test_init_with_provided_runner_uses_provided_runner(
-        self, mock_command_runner: Mock
+        self, runner: FakeCommandRunner
     ) -> None:
-        """Test that constructor uses the provided command runner."""
-        # Act
-        service = GitHubCliPullRequestService(runner=mock_command_runner)
-
-        # Assert
-        assert service._runner is mock_command_runner
+        service = GitHubCliPullRequestService(runner=runner)
+        assert service._runner is runner
 
     def test_init_with_none_runner_creates_subprocess_runner(self) -> None:
-        """Test that constructor creates SubprocessCommandRunner when runner is None."""
-        # Act
         service = GitHubCliPullRequestService(runner=None)
-
-        # Assert
-        # We can't directly test the type due to imports, but we can test it's not None
         assert service._runner is not None
 
     def test_init_without_runner_parameter_creates_default_runner(self) -> None:
-        """Test that constructor creates default runner when no parameter provided."""
-        # Act
         service = GitHubCliPullRequestService()
-
-        # Assert
         assert service._runner is not None
 
     def test_open_calls_gh_pr_create_with_correct_parameters(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
         sample_pull_request: ReleasePullRequest,
     ) -> None:
-        """Test that open() calls gh pr create with the correct parameters."""
-        # Arrange
         expected_url = "https://github.com/owner/repo/pull/123"
-        mock_command_runner.run.return_value = expected_url
+        runner.configured_outputs = [expected_url]
 
-        expected_command = [
+        expected_cmd = [
             "gh",
             "pr",
             "create",
@@ -83,103 +61,73 @@ class TestGitHubCliPullRequestService:
             "Automated release for version 1.2.3",
         ]
 
-        # Act
-        service_with_mock_runner.open(sample_pull_request)
+        service = GitHubCliPullRequestService(runner=runner)
+        service.open(sample_pull_request)
 
-        # Assert
-        mock_command_runner.run.assert_called_once_with(expected_command)
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == expected_cmd
 
     def test_open_extracts_pr_id_from_url(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
         sample_pull_request: ReleasePullRequest,
     ) -> None:
-        """Test that open() correctly extracts PR ID from the returned URL."""
-        # Arrange
         expected_url = "https://github.com/owner/repo/pull/456/"
-        mock_command_runner.run.return_value = expected_url
+        runner.configured_outputs = [expected_url]
 
-        # Act
-        result = service_with_mock_runner.open(sample_pull_request)
+        service = GitHubCliPullRequestService(runner=runner)
+        result = service.open(sample_pull_request)
 
-        # Assert
         assert result.pr_id == "456"
         assert result.url == expected_url
 
     def test_open_handles_url_without_trailing_slash(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
         sample_pull_request: ReleasePullRequest,
     ) -> None:
-        """Test that open() handles URLs without trailing slash."""
-        # Arrange
         expected_url = "https://github.com/owner/repo/pull/789"
-        mock_command_runner.run.return_value = expected_url
+        runner.configured_outputs = [expected_url]
 
-        # Act
-        result = service_with_mock_runner.open(sample_pull_request)
+        service = GitHubCliPullRequestService(runner=runner)
+        result = service.open(sample_pull_request)
 
-        # Assert
         assert result.pr_id == "789"
         assert result.url == expected_url
 
     def test_open_returns_open_pull_request_output(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
         sample_pull_request: ReleasePullRequest,
     ) -> None:
-        """Test that open() returns OpenPullRequestOutput with correct data."""
-        # Arrange
-        expected_url = "https://github.com/owner/repo/pull/123"
-        mock_command_runner.run.return_value = expected_url
+        expected_url = "https://github.com/owner/repo/pull/1"
+        runner.configured_outputs = [expected_url]
 
-        # Act
-        result = service_with_mock_runner.open(sample_pull_request)
+        service = GitHubCliPullRequestService(runner=runner)
+        result = service.open(sample_pull_request)
 
-        # Assert
         assert isinstance(result, OpenPullRequestOutput)
-        assert result.pr_id == "123"
+        assert result.pr_id == "1"
         assert result.url == expected_url
 
-    @pytest.mark.parametrize(
-        "pr_url, expected_pr_id",
-        [
-            ("https://github.com/owner/repo/pull/42", "42"),
-            ("https://github.com/owner/repo/pull/999/", "999"),
-            ("https://github.com/different-owner/different-repo/pull/1337", "1337"),
-            ("https://github.com/test/test/pull/1", "1"),
-            ("https://github.com/org/project/pull/12345/", "12345"),
-        ],
-    )
-    def test_open_extracts_correct_pr_id_from_various_urls(
+    def test_open_handles_alternative_url_format(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
         sample_pull_request: ReleasePullRequest,
-        pr_url: str,
-        expected_pr_id: str,
     ) -> None:
-        """Test that open() correctly extracts PR ID from various URL formats."""
-        # Arrange
-        mock_command_runner.run.return_value = pr_url
+        expected_url = "https://github.com/forging-blocks-org/forging-blocks/pull/42"
+        runner.configured_outputs = [expected_url]
 
-        # Act
-        result = service_with_mock_runner.open(sample_pull_request)
+        service = GitHubCliPullRequestService(runner=runner)
+        result = service.open(sample_pull_request)
 
-        # Assert
-        assert result.pr_id == expected_pr_id
-        assert result.url == pr_url
+        assert result.pr_id == "42"
+        assert result.url == expected_url
 
     def test_open_with_different_pull_request_data(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
     ) -> None:
-        """Test that open() works with different pull request data."""
-        # Arrange
         pr = ReleasePullRequest(
             base="main",
             head=ReleaseBranchName("release/v2.0.1"),
@@ -188,9 +136,9 @@ class TestGitHubCliPullRequestService:
         )
 
         expected_url = "https://github.com/org/repo/pull/100"
-        mock_command_runner.run.return_value = expected_url
+        runner.configured_outputs = [expected_url]
 
-        expected_command = [
+        expected_cmd = [
             "gh",
             "pr",
             "create",
@@ -204,21 +152,18 @@ class TestGitHubCliPullRequestService:
             "This is a pre-release with breaking changes.\n\nSee CHANGELOG.md for details.",
         ]
 
-        # Act
-        result = service_with_mock_runner.open(pr)
+        service = GitHubCliPullRequestService(runner=runner)
+        result = service.open(pr)
 
-        # Assert
-        mock_command_runner.run.assert_called_once_with(expected_command)
+        assert len(runner.calls) == 1
+        assert runner.calls[0][0] == expected_cmd
         assert result.pr_id == "100"
         assert result.url == expected_url
 
     def test_open_uses_release_branch_name_value(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
     ) -> None:
-        """Test that open() correctly uses the ReleaseBranchName.value property."""
-        # Arrange
         branch_name = ReleaseBranchName("release/v3.1.4")
         pr = ReleasePullRequest(
             base="main",
@@ -227,23 +172,19 @@ class TestGitHubCliPullRequestService:
             body="Test Body",
         )
 
-        mock_command_runner.run.return_value = "https://github.com/test/repo/pull/1"
+        runner.configured_outputs = ["https://github.com/test/repo/pull/1"]
 
-        # Act
-        service_with_mock_runner.open(pr)
+        service = GitHubCliPullRequestService(runner=runner)
+        service.open(pr)
 
-        # Assert
-        call_args = mock_command_runner.run.call_args[0][0]
+        call_args = runner.calls[0][0]
         head_index = call_args.index("--head") + 1
         assert call_args[head_index] == "release/v3.1.4"
 
     def test_open_with_special_characters_in_title_and_body(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
     ) -> None:
-        """Test that open() handles special characters in title and body."""
-        # Arrange
         pr = ReleasePullRequest(
             base="main",
             head=ReleaseBranchName("release/v1.0.0"),
@@ -252,54 +193,43 @@ class TestGitHubCliPullRequestService:
         )
 
         expected_url = "https://github.com/test/repo/pull/42"
-        mock_command_runner.run.return_value = expected_url
+        runner.configured_outputs = [expected_url]
 
-        # Act
-        result = service_with_mock_runner.open(pr)
+        service = GitHubCliPullRequestService(runner=runner)
+        result = service.open(pr)
 
-        # Assert
-        call_args = mock_command_runner.run.call_args[0][0]
-
+        call_args = runner.calls[0][0]
         title_index = call_args.index("--title") + 1
         body_index = call_args.index("--body") + 1
 
         assert call_args[title_index] == 'Release v1.0.0: Major Update with "Quotes" & Symbols'
-        assert (
-            call_args[body_index]
-            == "Release notes:\n- Feature A\n- Bug fix for issue #123\n- Update dependencies"
+        assert call_args[body_index] == (
+            "Release notes:\n- Feature A\n- Bug fix for issue #123\n- Update dependencies"
         )
-
         assert result.pr_id == "42"
         assert result.url == expected_url
 
     def test_open_command_structure_is_correct(
         self,
-        service_with_mock_runner: GitHubCliPullRequestService,
-        mock_command_runner: Mock,
+        runner: FakeCommandRunner,
         sample_pull_request: ReleasePullRequest,
     ) -> None:
-        """Test that the gh command structure follows the expected format."""
-        # Arrange
-        mock_command_runner.run.return_value = "https://github.com/test/repo/pull/1"
+        runner.configured_outputs = ["https://github.com/test/repo/pull/1"]
 
-        # Act
-        service_with_mock_runner.open(sample_pull_request)
+        service = GitHubCliPullRequestService(runner=runner)
+        service.open(sample_pull_request)
 
-        # Assert
-        call_args = mock_command_runner.run.call_args[0][0]
+        call_args = runner.calls[0][0]
 
-        # Verify command structure
         assert call_args[0] == "gh"
         assert call_args[1] == "pr"
         assert call_args[2] == "create"
 
-        # Verify all required flags are present
         assert "--base" in call_args
         assert "--head" in call_args
         assert "--title" in call_args
         assert "--body" in call_args
 
-        # Verify values follow flags
         base_index = call_args.index("--base")
         head_index = call_args.index("--head")
         title_index = call_args.index("--title")

--- a/tests/scripts/release/infrastructure/handlers/test_open_pull_request_handler_new.py
+++ b/tests/scripts/release/infrastructure/handlers/test_open_pull_request_handler_new.py
@@ -1,9 +1,10 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
-from unittest.mock import AsyncMock, MagicMock, create_autospec
-
 import pytest
 from scripts.release.application.ports.inbound import (
     OpenReleasePullRequestInput,
+    OpenReleasePullRequestOutput,
+)
+from scripts.release.application.ports.inbound.open_release_pull_request_use_case import (
     OpenReleasePullRequestUseCase,
 )
 from scripts.release.domain.commands.open_pull_request_command import (
@@ -14,38 +15,52 @@ from scripts.release.infrastructure.handlers.open_pull_request_handler import (
 )
 
 
+class FakeOpenReleasePullRequestUseCase(OpenReleasePullRequestUseCase):
+    """State-based use-case fake — records inputs and returns configured output."""
+
+    def __init__(self) -> None:
+        self.execute_calls: list[OpenReleasePullRequestInput] = []
+        self._raise: Exception | None = None
+
+    async def execute(self, request: OpenReleasePullRequestInput) -> OpenReleasePullRequestOutput:
+        if self._raise is not None:
+            raise self._raise
+        self.execute_calls.append(request)
+        return OpenReleasePullRequestOutput(pr_id=None, url=None)
+
+
 @pytest.mark.unit
 class TestOpenPullRequestHandler:
     @pytest.fixture
-    def use_case_mock(self) -> MagicMock:
-        return create_autospec(OpenReleasePullRequestUseCase, instance=True)
+    def use_case(self) -> FakeOpenReleasePullRequestUseCase:
+        return FakeOpenReleasePullRequestUseCase()
 
     @pytest.fixture
-    def handler(self, use_case_mock: MagicMock) -> OpenPullRequestHandler:
-        return OpenPullRequestHandler(use_case_mock)
+    def handler(self, use_case: FakeOpenReleasePullRequestUseCase) -> OpenPullRequestHandler:
+        return OpenPullRequestHandler(use_case)
 
     @pytest.fixture
     def command(self) -> OpenPullRequestCommand:
         return OpenPullRequestCommand(version="1.2.0", branch="release/v1.2.0", dry_run=False)
 
-    def test_init_when_called_then_sets_use_case(self, use_case_mock: MagicMock) -> None:
-        handler = OpenPullRequestHandler(use_case_mock)
+    def test_init_when_called_then_sets_use_case(
+        self, use_case: FakeOpenReleasePullRequestUseCase
+    ) -> None:
+        handler = OpenPullRequestHandler(use_case)
 
-        assert handler._use_case == use_case_mock
+        assert handler._use_case is use_case
 
     @pytest.mark.asyncio
     async def test_handle_when_called_then_creates_pr_input_with_command_data(
         self,
         handler: OpenPullRequestHandler,
-        use_case_mock: MagicMock,
+        use_case: FakeOpenReleasePullRequestUseCase,
         command: OpenPullRequestCommand,
     ) -> None:
-        use_case_mock.execute = AsyncMock()
-
         await handler.handle(command)
 
-        use_case_mock.execute.assert_called_once()
-        call_args = use_case_mock.execute.call_args[0][0]
+        assert len(use_case.execute_calls) == 1
+        call_args = use_case.execute_calls[0]
         assert isinstance(call_args, OpenReleasePullRequestInput)
         assert call_args.version == "1.2.0"
         assert call_args.branch == "release/v1.2.0"
@@ -53,64 +68,56 @@ class TestOpenPullRequestHandler:
 
     @pytest.mark.asyncio
     async def test_handle_when_dry_run_true_then_passes_dry_run_to_use_case(
-        self, handler: OpenPullRequestHandler, use_case_mock: MagicMock
+        self, handler: OpenPullRequestHandler, use_case: FakeOpenReleasePullRequestUseCase
     ) -> None:
-        use_case_mock.execute = AsyncMock()
         command = OpenPullRequestCommand(version="2.0.0", branch="release/v2.0.0", dry_run=True)
 
         await handler.handle(command)
 
-        call_args = use_case_mock.execute.call_args[0][0]
-        assert call_args.dry_run is True
+        assert use_case.execute_calls[0].dry_run is True
 
     @pytest.mark.asyncio
     async def test_handle_when_use_case_raises_exception_then_propagates(
         self,
         handler: OpenPullRequestHandler,
-        use_case_mock: MagicMock,
+        use_case: FakeOpenReleasePullRequestUseCase,
         command: OpenPullRequestCommand,
     ) -> None:
-        use_case_mock.execute = AsyncMock(side_effect=RuntimeError("Use case failed"))
+        use_case._raise = RuntimeError("Use case failed")
 
         with pytest.raises(RuntimeError, match="Use case failed"):
             await handler.handle(command)
 
     @pytest.mark.asyncio
     async def test_handle_when_called_with_different_versions_then_maps_correctly(
-        self, handler: OpenPullRequestHandler, use_case_mock: MagicMock
+        self, handler: OpenPullRequestHandler, use_case: FakeOpenReleasePullRequestUseCase
     ) -> None:
-        use_case_mock.execute = AsyncMock()
         versions = ["1.0.0", "2.1.3", "10.5.7"]
 
         for version in versions:
             command = OpenPullRequestCommand(
                 version=version, branch=f"release/v{version}", dry_run=False
             )
-
             await handler.handle(command)
 
-            call_args = use_case_mock.execute.call_args[0][0]
-            assert call_args.version == version
-            assert call_args.branch == f"release/v{version}"
+        assert len(use_case.execute_calls) == 3
+        assert use_case.execute_calls[0].version == "1.0.0"
+        assert use_case.execute_calls[1].version == "2.1.3"
+        assert use_case.execute_calls[2].version == "10.5.7"
 
     @pytest.mark.asyncio
     async def test_handle_when_called_multiple_times_then_each_call_creates_separate_input(
-        self, handler: OpenPullRequestHandler, use_case_mock: MagicMock
+        self, handler: OpenPullRequestHandler, use_case: FakeOpenReleasePullRequestUseCase
     ) -> None:
-        use_case_mock.execute = AsyncMock()
-
         command1 = OpenPullRequestCommand(version="1.0.0", branch="release/v1.0.0", dry_run=False)
         command2 = OpenPullRequestCommand(version="2.0.0", branch="release/v2.0.0", dry_run=True)
 
         await handler.handle(command1)
         await handler.handle(command2)
 
-        assert use_case_mock.execute.call_count == 2
+        assert len(use_case.execute_calls) == 2
 
-        first_call_args = use_case_mock.execute.call_args_list[0][0][0]
-        second_call_args = use_case_mock.execute.call_args_list[1][0][0]
-
-        assert first_call_args.version == "1.0.0"
-        assert first_call_args.dry_run is False
-        assert second_call_args.version == "2.0.0"
-        assert second_call_args.dry_run is True
+        assert use_case.execute_calls[0].version == "1.0.0"
+        assert use_case.execute_calls[0].dry_run is False
+        assert use_case.execute_calls[1].version == "2.0.0"
+        assert use_case.execute_calls[1].dry_run is True


### PR DESCRIPTION
- **feat(foundation): add context types for service, authorization, and transaction**
- **feat(foundation): add IsolationLevel and Permission enums**
- **feat(foundation): add ValidationRule in rules module and re-export from foundation**
- **feat(domain): add validators — Required, Email, and Length**
- **feat(domain): add RangeValidator and CompositeValidationRule**
- **feat(domain): add permission checker protocol, role and resource implementations**
- **feat(domain): add CompositePermissionChecker and re-export from domain**
- **feat(application): add ApplicationService, ValidationService, and AuthorizationService ports**
- **feat(application): add TransactionManagerPort outbound port**
- **feat(application): add TransactionError**
- **docs(domain): add permissions and validators reference pages**
- **docs(foundation): add context and rules reference pages**
- **test(foundation): add tests for IsolationLevel and Permission enums**
- **test(foundation): add tests for context objects**
- **test(foundation): add tests for ValidationRule**
- **test(domain): add test for PermissionChecker protocol**
- **test(domain): add tests for RoleBasedPermissionChecker**
- **test(domain): add tests for ResourcePermissionChecker and CompositePermissionChecker**
- **test(domain): add tests for Required, Email, and Length validators**
- **test(domain): add tests for RangeValidator and CompositeValidationRule**
- **test(application): add test for TransactionError**
- **test(application): add tests for inbound port protocols**
- **chore(application): add dtos package init**
- **test(fixtures): add FakeCommandRunner, FakeEventPublisher, and FakeMessageBus**
- **test(message-bus): replace MagicMock with FakeMessageBus fixture**
- **test(unit-of-work): replace AsyncMock with FakeEventPublisher fixture**
- **test(http-client): add local echo server fixture achieving 100% coverage**
- **test(release-bus): replace AsyncMock with FakeHandler and FakeCommand fixtures**
- **test(release-infra): replace create_autospec with FakeCommandRunner fixture**
- **test(release-handler): replace create_autospec with FakeOpenReleasePullRequestUseCase**
- **test(process): replace @patch with real subprocess-driven tests**
- **test(e2e): replace MagicMock/AsyncMock with FakePullRequestService**
- **docs(foundation): fix broken relative link to domain validators page**
