### PR TITLE
feat/coverage closure 92

### DIFF
--- a/tests/forging_blocks/foundation/autofreeze/test_auto_freeze.py
+++ b/tests/forging_blocks/foundation/autofreeze/test_auto_freeze.py
@@ -12,16 +12,10 @@ from forging_blocks.foundation.errors.cant_modify_immutable_attribute_error impo
     CantModifyImmutableAttributeError,
 )
 
-# ---------------------------------------------------------------------------
-# Tests for the auto_freeze decorator
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.unit
 class TestAutoFreezeDecorator:
     """Tests for the auto_freeze decorator public API."""
-
-    # -- Usage modes --------------------------------------------------------
 
     def test_when_used_without_parentheses_then_decorates_class(self) -> None:
         class MyClass:
@@ -57,8 +51,6 @@ class TestAutoFreezeDecorator:
         first = auto_freeze(MyClass)
         second = auto_freeze(first)
         assert first is second
-
-    # -- Freeze behavior ----------------------------------------------------
 
     def test_when_attrs_is_none_then_freezes_entire_instance(self) -> None:
         class MyClass:
@@ -100,8 +92,6 @@ class TestAutoFreezeDecorator:
         with pytest.raises(ValueError, match="fail"):
             decorated(-1)
 
-    # -- Selective freezing -------------------------------------------------
-
     def test_when_attrs_is_list_then_only_those_attributes_frozen(self) -> None:
         class MyClass:
             def __init__(self, a: int, b: int, c: int) -> None:
@@ -131,8 +121,6 @@ class TestAutoFreezeDecorator:
         instance.a = 99
         assert instance.a == 99
 
-    # -- Abstract classes ---------------------------------------------------
-
     def test_when_class_is_abstract_then_not_frozen(self) -> None:
         from abc import ABC, abstractmethod
 
@@ -157,8 +145,6 @@ class TestAutoFreezeDecorator:
         with pytest.raises(CantModifyImmutableAttributeError):
             instance.value = 99
 
-    # -- Existing __setattr__ preservation ----------------------------------
-
     def test_when_class_has_custom_setattr_then_class_handles_freezing(self) -> None:
         """When a class has custom __setattr__, it must handle frozen checks itself."""
 
@@ -167,13 +153,11 @@ class TestAutoFreezeDecorator:
                 self._value = value
 
             def __setattr__(self, name: str, value: Any) -> None:
-                # Frozen check must come FIRST for frozen objects
                 if getattr(self, "_autofreeze__frozen", False):
                     raise CantModifyImmutableAttributeError(
                         class_name=self.__class__.__name__,
                         attribute_name=name,
                     )
-                # Custom validation
                 if name == "_value" and value < 0:
                     raise ValueError("value must be non-negative")
                 object.__setattr__(self, name, value)
@@ -181,8 +165,6 @@ class TestAutoFreezeDecorator:
         decorated = auto_freeze(MyClass)
         instance = decorated(10)
 
-        # Custom validation works during __init__ (before freeze)
-        # After freeze, class's own frozen check blocks modifications
         with pytest.raises(CantModifyImmutableAttributeError):
             instance._value = -5
 
@@ -226,11 +208,8 @@ class TestAutoFreezeDecorator:
             instance._a = 99
         with pytest.raises(CantModifyImmutableAttributeError):
             instance._b = 99
-        # _c is NOT frozen — should succeed
         instance._c = 99
         assert instance._c == 99
-
-    # -- Inheritance (requires manual decorator on each class) -------------
 
     def test_when_subclass_also_decorated_then_frozen_independently(self) -> None:
         @auto_freeze
@@ -285,8 +264,6 @@ class TestAutoFreezeDecorator:
         decorated = auto_freeze(AsyncFreeze)
         instance = decorated()
         assert instance is not None
-
-    # -- super().__init__ chaining -----------------------------------------
 
     def test_when_super_init_chaining_then_freezes_at_end(self) -> None:
         from abc import ABC, abstractmethod

--- a/tests/forging_blocks/foundation/autofreeze/test_auto_freeze.py
+++ b/tests/forging_blocks/foundation/autofreeze/test_auto_freeze.py
@@ -317,3 +317,52 @@ class TestAutoFreezeDecorator:
             instance.base_value = 99
         with pytest.raises(CantModifyImmutableAttributeError):
             instance.extra = "hacked"
+
+
+@pytest.mark.unit
+class TestFrozenStateManagerStaleFallback:
+    """Tests for FrozenStateManager stale fallback entry cleanup."""
+
+    def test_read_is_frozen_when_stale_qualifier_then_deletes_entry_and_returns_false(
+        self,
+    ) -> None:
+        from forging_blocks.foundation.autofreeze.helpers.frozen_state import (
+            FrozenStateManager,
+        )
+
+        class SomeClass:
+            pass
+
+        instance = SomeClass()
+        key = FrozenStateManager._fallback_key(instance)
+        FrozenStateManager._frozen_fallback[key] = ("WrongQualifier", True)
+
+        try:
+            result = FrozenStateManager._read_is_frozen(instance)
+            assert result is False
+            assert key not in FrozenStateManager._frozen_fallback
+        finally:
+            FrozenStateManager._frozen_fallback.pop(key, None)
+            FrozenStateManager._refs_by_id.pop(key, None)
+
+    def test_read_frozen_attrs_when_stale_qualifier_then_deletes_entry_and_returns_none(
+        self,
+    ) -> None:
+        from forging_blocks.foundation.autofreeze.helpers.frozen_state import (
+            FrozenStateManager,
+        )
+
+        class SomeClass:
+            pass
+
+        instance = SomeClass()
+        key = FrozenStateManager._fallback_key(instance)
+        FrozenStateManager._frozen_attrs_fallback[key] = ("WrongQualifier", {"x", "y"})
+
+        try:
+            result = FrozenStateManager._read_frozen_attrs(instance)
+            assert result is None
+            assert key not in FrozenStateManager._frozen_attrs_fallback
+        finally:
+            FrozenStateManager._frozen_attrs_fallback.pop(key, None)
+            FrozenStateManager._refs_by_id.pop(key, None)

--- a/tests/forging_blocks/foundation/autohash/test_auto_hash.py
+++ b/tests/forging_blocks/foundation/autohash/test_auto_hash.py
@@ -428,3 +428,19 @@ class TestAutoHashDecorator:
         instance = WithSet("x", {1, 2})
         with pytest.raises(NonHashableValueError, match="Cannot convert"):
             hash(instance)
+
+
+@pytest.mark.unit
+class TestHashableConverterDeeplyHashable:
+    """Tests for HashableConverter._ensure_deeply_hashable internals."""
+
+    def test_ensure_deeply_hashable_when_frozenset_then_recursively_converts_elements(
+        self,
+    ) -> None:
+        from forging_blocks.foundation.autohash.helpers.hashable_converter import (
+            HashableConverter,
+        )
+
+        result = HashableConverter._ensure_deeply_hashable(frozenset([1, 2, 3]))
+        assert isinstance(result, frozenset)
+        assert result == frozenset([1, 2, 3])

--- a/tests/forging_blocks/foundation/autohash/test_auto_hash.py
+++ b/tests/forging_blocks/foundation/autohash/test_auto_hash.py
@@ -14,16 +14,10 @@ from forging_blocks.foundation.errors.non_hashable_value_error import (
     NonHashableValueError,
 )
 
-# ---------------------------------------------------------------------------
-# Tests for the auto_hash decorator
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.unit
 class TestAutoHashDecorator:
     """Tests for the auto_hash decorator public API."""
-
-    # -- Usage modes --------------------------------------------------------
 
     def test_when_used_without_parentheses_then_decorates_class(self) -> None:
         @auto_hash
@@ -61,12 +55,9 @@ class TestAutoHashDecorator:
 
         original_hash = MyClass.__hash__
 
-        # Decorating again replaces __hash__
         redecorated = auto_hash(MyClass)
         assert redecorated is MyClass
         assert redecorated.__hash__ is not original_hash
-
-    # -- Hash behavior ------------------------------------------------------
 
     def test_when_dataclass_all_fields_then_equal_objects_have_equal_hash(self) -> None:
         @auto_hash
@@ -105,7 +96,6 @@ class TestAutoHashDecorator:
         p1 = Point(1, 2)
         p2 = Point(1, 999)
 
-        # Same x, different y — should be equal hash since only x used
         assert hash(p1) == hash(p2)
 
     def test_when_none_field_value_then_hash_does_not_raise(self) -> None:
@@ -115,7 +105,6 @@ class TestAutoHashDecorator:
             name: str | None
 
         t = OptionalThing(None)
-        # Should not raise
         _ = hash(t)
 
     def test_when_single_field_then_hash_matches_tuple_of_one(self) -> None:
@@ -185,8 +174,6 @@ class TestAutoHashDecorator:
         with pytest.raises(CantModifyImmutableAttributeError):
             p.x = 999
 
-    # -- Plain classes ------------------------------------------------------
-
     def test_when_plain_class_with_slots_then_hash_works(self) -> None:
         @auto_hash
         class Slotted:
@@ -210,7 +197,7 @@ class TestAutoHashDecorator:
 
             def __init__(self, x: int) -> None:
                 self.x = x
-                self.__cached__ = hash(x)  # dunder slot ignored
+                self.__cached__ = hash(x)
 
         s1 = SlottedWithDunder(5)
         s2 = SlottedWithDunder(5)
@@ -338,9 +325,7 @@ class TestAutoHashDecorator:
             y: int
 
         p = Point(1, 2)
-        # Hashing works (auto_hash applied)
         assert hash(p) == hash(Point(1, 2))
-        # Immutability works (auto_freeze applied, idempotent)
         with pytest.raises(CantModifyImmutableAttributeError):
             p.x = 99
 
@@ -357,8 +342,6 @@ class TestAutoHashDecorator:
         with pytest.raises(CantModifyImmutableAttributeError):
             p.x = 99
 
-    # -- Integration: sets --------------------------------------------------
-
     def test_when_hash_consistent_then_set_deduplicates(self) -> None:
         @auto_freeze
         @auto_hash
@@ -374,8 +357,6 @@ class TestAutoHashDecorator:
 
         assert len(unique) == 2
 
-    # -- Unhashable field types -------------------------------------------
-
     def test_when_list_field_then_converted_to_tuple_for_hash(self) -> None:
         @auto_freeze
         @auto_hash
@@ -390,7 +371,6 @@ class TestAutoHashDecorator:
 
         assert hash(a) == hash(b)
         assert hash(a) != hash(c)
-        # Verify set dedup works
         assert len({a, b, c}) == 2
 
     def test_when_dict_field_then_converted_to_frozenset_for_hash(self) -> None:
@@ -424,7 +404,6 @@ class TestAutoHashDecorator:
             id: str
             values: set[int]
 
-        # sets are not converted — should raise
         instance = WithSet("x", {1, 2})
         with pytest.raises(NonHashableValueError, match="Cannot convert"):
             hash(instance)

--- a/tests/forging_blocks/foundation/messages/test_message.py
+++ b/tests/forging_blocks/foundation/messages/test_message.py
@@ -251,3 +251,35 @@ class TestMessage:
     def test_cannot_instantiate_abstract_message_directly(self):
         with pytest.raises(TypeError, match="abstract"):
             type.__call__(Message)
+
+
+@pytest.mark.unit
+class TestMessageDataclassDecorator:
+    """Tests for the message_dataclass decorator internals."""
+
+    def test_message_dataclass_when_patched_message_check_fails_then_type_error(
+        self,
+    ) -> None:
+        from unittest.mock import patch
+
+        from forging_blocks.foundation.messages.decorators import (
+            _PatchedMessage,  # pyright: ignore[reportPrivateUsage]
+            message_dataclass,
+        )
+
+        class NotAMessage:
+            x: int
+
+        original_isinstance = isinstance
+
+        def _selective_isinstance(obj: object, cls: type) -> bool:
+            if cls is _PatchedMessage:
+                return False
+            return original_isinstance(obj, cls)
+
+        with patch(
+            "forging_blocks.foundation.messages.decorators.isinstance",
+            side_effect=_selective_isinstance,
+        ):
+            with pytest.raises(TypeError, match="does not satisfy _PatchedMessage"):
+                message_dataclass(NotAMessage)  # type: ignore[reportArgumentType]

--- a/tests/forging_blocks/infrastructure/caching/test_in_memory_cache.py
+++ b/tests/forging_blocks/infrastructure/caching/test_in_memory_cache.py
@@ -7,7 +7,7 @@ import pytest
 from forging_blocks.infrastructure.caching.in_memory_cache import InMemoryCache
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryCache:
     """Tests for InMemoryCache implementation."""
 

--- a/tests/forging_blocks/infrastructure/errors/test_repository_errors.py
+++ b/tests/forging_blocks/infrastructure/errors/test_repository_errors.py
@@ -8,7 +8,7 @@ from forging_blocks.infrastructure.errors.repository_errors import (
 )
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestRepositoryError:
     def test_init_when_message_defined_then_stores_message(self) -> None:
         message = ErrorMessage("Save failed")
@@ -29,7 +29,7 @@ class TestRepositoryError:
         assert isinstance(error, RepositoryError)
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestRepositoryNotFoundError:
     def test_for_id_when_called_then_returns_error_with_descriptive_message(self) -> None:
         error = RepositoryNotFoundError.for_id("abc-123")

--- a/tests/forging_blocks/infrastructure/event_buses/test_in_memory_event_bus.py
+++ b/tests/forging_blocks/infrastructure/event_buses/test_in_memory_event_bus.py
@@ -18,7 +18,7 @@ from tests.fixtures.fake_event_with_name import FakeEventWithName
 from tests.fixtures.simple_fake_command import SimpleFakeCommand
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryEventBus:
     """InMemoryEventBus publish / send / register behaviour."""
 

--- a/tests/forging_blocks/infrastructure/event_buses/test_in_memory_event_bus.py
+++ b/tests/forging_blocks/infrastructure/event_buses/test_in_memory_event_bus.py
@@ -77,3 +77,18 @@ class TestInMemoryEventBus:
         result = await bus.publish(FakeEventWithName("boom"))
         assert result.is_err
         assert isinstance(result.error, EventBusError)
+
+    async def test_send_when_handler_raises_then_returns_error(self) -> None:
+        """Sending a command whose handler raises returns ``EventBusError``."""
+        bus: InMemoryEventBus[dict[str, object], dict[str, object]] = InMemoryEventBus()
+
+        class FailingHandler(CommandHandler[dict[str, object]]):
+            async def handle(self, message: Command[dict[str, object]]) -> None:
+                raise RuntimeError("Handler exploded")
+
+        bus.register_handler(SimpleFakeCommand, FailingHandler())
+
+        result = await bus.send(SimpleFakeCommand("crash"))
+        assert result.is_err
+        assert isinstance(result.error, EventBusError)
+        assert "Handler exploded" in str(result.error.message)

--- a/tests/forging_blocks/infrastructure/event_buses/test_in_memory_event_bus_base.py
+++ b/tests/forging_blocks/infrastructure/event_buses/test_in_memory_event_bus_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from forging_blocks.application.errors.event_bus_error import EventBusError
 from forging_blocks.application.ports.inbound.message_handler import CommandHandler, EventHandler
 from forging_blocks.foundation.messages.command import Command
 from forging_blocks.foundation.messages.event import Event
@@ -102,3 +103,20 @@ class TestInMemoryEventBusBase:
         result = await event_bus.send(command)
         assert result.is_ok
         assert len(received_commands) == 1
+
+    async def test_send_when_handler_raises_then_returns_error(
+        self,
+        event_bus: InMemoryEventBusBase[TestPayload, TestPayload],
+    ) -> None:
+        """Sending a command whose handler raises returns ``EventBusError``."""
+
+        class FailingHandler(CommandHandler[TestPayload]):
+            async def handle(self, message: Command[TestPayload]) -> None:
+                raise RuntimeError("Handler exploded")
+
+        event_bus.register_handler(SimpleFakeCommandWithValue, FailingHandler())
+        command = SimpleFakeCommandWithValue("crash")
+        result = await event_bus.send(command)
+        assert result.is_err
+        assert isinstance(result.error, EventBusError)
+        assert "Handler exploded" in str(result.error.message)

--- a/tests/forging_blocks/infrastructure/event_stores/test_in_memory_event_store.py
+++ b/tests/forging_blocks/infrastructure/event_stores/test_in_memory_event_store.py
@@ -12,7 +12,7 @@ from forging_blocks.infrastructure.event_stores.in_memory_event_store import (
 from tests.fixtures.fake_event_with_name import FakeEventWithName
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryEventStore:
     """InMemoryEventStore append / get / version behaviour."""
 

--- a/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
+++ b/tests/forging_blocks/infrastructure/message_bus/test_in_memory_message_bus.py
@@ -48,7 +48,7 @@ class FakeQuery(Query[dict[str, Any]]):
         return cls(data=str(data.get("data", "")), metadata=metadata)
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryMessageBus:
     def test_init_when_created_then_has_empty_handler_registry(self) -> None:
         bus: InMemoryMessageBus[Command[object], object] = InMemoryMessageBus[

--- a/tests/forging_blocks/infrastructure/repositories/test_aggregate_repository.py
+++ b/tests/forging_blocks/infrastructure/repositories/test_aggregate_repository.py
@@ -69,7 +69,7 @@ class FailingGetEventsStore(InMemoryEventStoreBase[object]):
         return Err(EventStoreError("Connection lost"))
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestAggregateRepository:
     async def test_save_and_retrieve_aggregate(self) -> None:
         repo = AggregateRepository[object, FakeAggregate, UUID](

--- a/tests/forging_blocks/infrastructure/repositories/test_aggregate_repository.py
+++ b/tests/forging_blocks/infrastructure/repositories/test_aggregate_repository.py
@@ -1,12 +1,15 @@
 """Tests for the AggregateRepository class."""
 
+from collections.abc import Sequence
 from typing import cast
 from uuid import UUID, uuid7
 
 import pytest
 
+from forging_blocks.application.errors.event_store_error import EventStoreError
 from forging_blocks.domain.aggregate_root.aggregate_root import AggregateRoot
 from forging_blocks.foundation.messages.event import Event
+from forging_blocks.foundation.result import Err, Result
 from forging_blocks.infrastructure.event_stores.in_memory_event_store_base import (
     InMemoryEventStoreBase,
 )
@@ -40,6 +43,30 @@ class FakeAggregate(AggregateRoot[UUID, object]):
     def _handle(self, event: Event[object]) -> None:
         if isinstance(event, FakeEvent):
             self.items.append(cast(str, event.value["name"]))
+
+
+class FailingAppendEventStore(InMemoryEventStoreBase[object]):
+    """Event store that returns Err from append_events."""
+
+    async def append_events(
+        self,
+        aggregate_id: UUID,
+        events: Sequence[Event[object]],
+        expected_version: int | None = None,
+    ) -> Result[int, EventStoreError]:
+        return Err(EventStoreError("Store is down"))
+
+
+class FailingGetEventsStore(InMemoryEventStoreBase[object]):
+    """Event store that returns Err from get_events."""
+
+    async def get_events(
+        self,
+        aggregate_id: UUID,
+        from_version: int | None = None,
+        to_version: int | None = None,
+    ) -> Result[Sequence[Event[object]], EventStoreError]:
+        return Err(EventStoreError("Connection lost"))
 
 
 @pytest.mark.unit
@@ -124,3 +151,23 @@ class TestAggregateRepository:
         retrieved = await repo.get_by_id(aggregate_id)
 
         assert retrieved is None
+
+    async def test_save_when_event_store_append_fails_then_raises_error(self) -> None:
+        repo = AggregateRepository[object, FakeAggregate, UUID](
+            event_store=FailingAppendEventStore(),
+        )
+        aggregate = FakeAggregate(uuid7())
+        aggregate.add_item("widget")
+
+        with pytest.raises(EventStoreError, match="Store is down"):
+            await repo.save(aggregate)
+
+    async def test_get_by_id_when_event_store_get_events_fails_then_raises_error(
+        self,
+    ) -> None:
+        repo = AggregateRepository[object, FakeAggregate, UUID](
+            event_store=FailingGetEventsStore(),
+        )
+
+        with pytest.raises(EventStoreError, match="Connection lost"):
+            await repo.get_by_id(uuid7())

--- a/tests/forging_blocks/infrastructure/repositories/test_in_memory_read_repository.py
+++ b/tests/forging_blocks/infrastructure/repositories/test_in_memory_read_repository.py
@@ -19,7 +19,7 @@ class FakeReadModel:
         return self.id == other.id and self.name == other.name
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryReadRepository:
     async def test_get_by_id_when_id_exists_then_returns_aggregate(self) -> None:
         storage = {"1": FakeReadModel("1", "Alice")}

--- a/tests/forging_blocks/infrastructure/repositories/test_in_memory_write_repository.py
+++ b/tests/forging_blocks/infrastructure/repositories/test_in_memory_write_repository.py
@@ -26,7 +26,7 @@ class FakeAggregate:
         return self.id == other.id and self.name == other.name
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryWriteRepository:
     @pytest.fixture
     def create_alice_aggregate(self) -> Callable[[str], FakeAggregate]:

--- a/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
+++ b/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
@@ -1,6 +1,5 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Any, Self
-from unittest.mock import PropertyMock, patch
 
 import pytest
 
@@ -45,7 +44,7 @@ class FakeAggregate(AggregateRoot[str, str]):
         pass
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestInMemoryUnitOfWork:
     @pytest.fixture
     def event_publisher(self) -> FakeEventPublisher:
@@ -58,6 +57,18 @@ class TestInMemoryUnitOfWork:
     @pytest.fixture
     def aggregate(self) -> FakeAggregate:
         return FakeAggregate("agg-1")
+
+    @pytest.fixture
+    def draft_aggregate(self) -> FakeAggregate:
+        """Return a FakeAggregate with _id set to None via object.__setattr__.
+
+        This simulates a draft entity that has not yet been persisted.
+        Using object.__setattr__ bypasses both the Entity.__setattr__ guard
+        and the auto_freeze mechanism.
+        """
+        agg = FakeAggregate("temp-id")
+        object.__setattr__(agg, "_id", None)
+        return agg
 
     async def test_commit_when_modified_aggregate_has_events_then_publishes_them(
         self, event_publisher: FakeEventPublisher, aggregate: FakeAggregate
@@ -184,10 +195,9 @@ class TestInMemoryUnitOfWork:
         assert uow.committed is False
 
     async def test_register_modified_when_aggregate_id_is_none_then_raises(
-        self, aggregate: FakeAggregate
+        self, draft_aggregate: FakeAggregate
     ) -> None:
         uow = InMemoryUnitOfWork()
 
-        with patch.object(FakeAggregate, "id", new_callable=PropertyMock(return_value=None)):
-            with pytest.raises(ValueError, match="Cannot register aggregate with None id"):
-                uow.register_modified(aggregate)
+        with pytest.raises(ValueError, match="Cannot register aggregate with None id"):
+            uow.register_modified(draft_aggregate)

--- a/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
+++ b/tests/forging_blocks/infrastructure/unit_of_work/test_in_memory_unit_of_work.py
@@ -1,5 +1,6 @@
 # pyright: reportPrivateUsage=false, reportMissingTypeArgument=false, reportUnknownParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportIncompatibleMethodOverride=false, reportUnusedClass=false, reportFunctionMemberAccess=false
 from typing import Any, Self
+from unittest.mock import PropertyMock, patch
 
 import pytest
 
@@ -155,3 +156,38 @@ class TestInMemoryUnitOfWork:
         await uow.rollback()
         assert uow.rolled_back is True
         assert uow.committed is False
+
+    async def test_context_manager_when_no_exception_then_commits(
+        self, event_publisher: FakeEventPublisher, aggregate: FakeAggregate
+    ) -> None:
+        uow = InMemoryUnitOfWork(event_publisher)
+        event = FakeEvent("data")
+        aggregate.record_event(event)
+
+        async with uow:
+            uow.register_modified(aggregate)
+
+        assert uow.committed is True
+        assert len(event_publisher.published_events) == 1
+
+    async def test_context_manager_when_exception_then_rolls_back(
+        self, event_publisher: FakeEventPublisher, aggregate: FakeAggregate
+    ) -> None:
+        uow = InMemoryUnitOfWork(event_publisher)
+
+        with pytest.raises(ValueError, match="boom"):
+            async with uow:
+                uow.register_modified(aggregate)
+                raise ValueError("boom")
+
+        assert uow.rolled_back is True
+        assert uow.committed is False
+
+    async def test_register_modified_when_aggregate_id_is_none_then_raises(
+        self, aggregate: FakeAggregate
+    ) -> None:
+        uow = InMemoryUnitOfWork()
+
+        with patch.object(FakeAggregate, "id", new_callable=PropertyMock(return_value=None)):
+            with pytest.raises(ValueError, match="Cannot register aggregate with None id"):
+                uow.register_modified(aggregate)


### PR DESCRIPTION
- **test(foundation): cover FrozenStateManager stale fallback entry cleanup**
- **test(foundation): cover HashableConverter frozenset branch**
- **test(foundation): cover message_dataclass TypeError on _PatchedMessage check**
- **test(infrastructure): cover InMemoryEventBus send handler exception path**
- **test(infrastructure): cover InMemoryEventBusBase publish/send handler exception paths**
- **test(infrastructure): cover AggregateRepository event store error paths**
- **test(infrastructure): cover InMemoryUnitOfWork context manager and None id guard**
- **test(foundation): remove comments from auto_freeze tests**
- **test(foundation): remove comments from auto_hash tests**
