### PR TITLE
chore(ci): add Semgrep SAST workflow with PR commenting

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,8 +7,8 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - 'poetry.lock'
-      - '.github/workflows/*.yml'
-      - '.github/actions/*.yml'
+      - '.github/workflows/**/*.yml'
+      - '.github/actions/**/*.yml'
   push:
     branches:
       - main
@@ -17,11 +17,14 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - 'poetry.lock'
+      - '.github/workflows/**/*.yml'
+      - '.github/actions/**/*.yml'
 
 permissions:
   contents: read
   security-events: write
   pull-requests: write
+  issues: write
 
 jobs:
   sast:
@@ -41,7 +44,6 @@ jobs:
             --json \
             --output=findings.json \
             src/ \
-            || true
 
       - name: Convert to SARIF
         run: |
@@ -50,7 +52,6 @@ jobs:
             --sarif \
             --output=findings.sarif \
             src/ \
-            || true
 
       - name: Upload to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -65,6 +66,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const MARKER = '<!-- static-analysis-results -->';
 
             if (!fs.existsSync('findings.json')) {
               console.log('No findings file generated');
@@ -84,7 +86,7 @@ jobs:
               return;
             }
 
-            let comment = '## Static Analysis Results\n\n';
+            let comment = MARKER + '\n## Static Analysis Results\n\n';
             comment += `Found **${findings.results.length}** issue(s):\n\n`;
 
             const grouped = findings.results.reduce((acc, result) => {
@@ -107,16 +109,32 @@ jobs:
               comment += '\n';
             });
 
-            comment += '_View full results in [Security > Code scanning](';
-            comment += context.payload.pull_request.html_url;
-            comment += '/security)_';
+            comment += '_View full results in [Security > Code scanning](https://github.com/${context.repo.owner}/${context.repo.repo}/security/code-scanning)_';
 
-            github.rest.issues.createComment({
+            // Find existing bot comment to update, or create new one
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: comment
             });
+
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment,
+              });
+            }
 
       - name: Enforce security policy
         if: always()
@@ -126,8 +144,8 @@ jobs:
           fi
 
           # Count critical/high issues
-          CRITICAL=$(jq '[.results[] | select(.extra.severity == "critical")] | length' findings.json 2>/dev/null || echo 0)
-          HIGH=$(jq '[.results[] | select(.extra.severity == "high")] | length' findings.json 2>/dev/null || echo 0)
+          CRITICAL=$(jq '[.results[] | select(.extra.severity == "critical")] | length' findings.json 2>/dev/null)
+          HIGH=$(jq '[.results[] | select(.extra.severity == "high")] | length' findings.json 2>/dev/null)
           TOTAL=$((CRITICAL + HIGH))
 
           if [ "$TOTAL" -gt 0 ]; then

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,138 @@
+name: Static Analysis
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/*.yml'
+      - '.github/actions/*.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  sast:
+    name: SAST Scan
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep scan
+        run: |
+          semgrep scan \
+            --config=p/security-audit \
+            --json \
+            --output=findings.json \
+            src/ \
+            || true
+
+      - name: Convert to SARIF
+        run: |
+          semgrep scan \
+            --config=p/security-audit \
+            --sarif \
+            --output=findings.sarif \
+            src/ \
+            || true
+
+      - name: Upload to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: findings.sarif
+          category: semgrep
+
+      - name: Comment findings on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            if (!fs.existsSync('findings.json')) {
+              console.log('No findings file generated');
+              return;
+            }
+
+            let findings;
+            try {
+              findings = JSON.parse(fs.readFileSync('findings.json', 'utf8'));
+            } catch (e) {
+              console.log('Could not parse findings');
+              return;
+            }
+
+            if (!findings.results || findings.results.length === 0) {
+              core.info('No security issues detected');
+              return;
+            }
+
+            let comment = '## Static Analysis Results\n\n';
+            comment += `Found **${findings.results.length}** issue(s):\n\n`;
+
+            const grouped = findings.results.reduce((acc, result) => {
+              const severity = result.extra?.severity || 'medium';
+              acc[severity] = (acc[severity] || []).concat(result);
+              return acc;
+            }, {});
+
+            ['critical', 'high', 'medium', 'low'].forEach(sev => {
+              if (!grouped[sev]) return;
+              comment += `### ${sev.toUpperCase()} (${grouped[sev].length})\n`;
+              grouped[sev].slice(0, 10).forEach(result => {
+                const line = result.start?.line || '?';
+                const rule = result.check_id || 'unknown';
+                comment += `- \`${result.path}:${line}\` — ${result.extra?.message || rule}\n`;
+              });
+              if (grouped[sev].length > 10) {
+                comment += `- ... and ${grouped[sev].length - 10} more\n`;
+              }
+              comment += '\n';
+            });
+
+            comment += '_View full results in [Security > Code scanning](';
+            comment += context.payload.pull_request.html_url;
+            comment += '/security)_';
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+      - name: Enforce security policy
+        if: always()
+        run: |
+          if [ ! -f findings.json ]; then
+            exit 0
+          fi
+
+          # Count critical/high issues
+          CRITICAL=$(jq '[.results[] | select(.extra.severity == "critical")] | length' findings.json 2>/dev/null || echo 0)
+          HIGH=$(jq '[.results[] | select(.extra.severity == "high")] | length' findings.json 2>/dev/null || echo 0)
+          TOTAL=$((CRITICAL + HIGH))
+
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "Security gate failed: Found $CRITICAL critical and $HIGH high severity issues"
+            exit 1
+          fi
+
+          echo "Security gate passed"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -109,7 +109,8 @@ jobs:
               comment += '\n';
             });
 
-            comment += '_View full results in [Security > Code scanning](https://github.com/${context.repo.owner}/${context.repo.repo}/security/code-scanning)_';
+            comment += '_View full results in [Security > Code scanning](https://github.com/' +
+              context.repo.owner + '/' + context.repo.repo + '/security/code-scanning)_';
 
             // Find existing bot comment to update, or create new one
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Summary

Adds a Semgrep SAST static analysis workflow (`.github/workflows/static-analysis.yml`) that:

- Runs Semgrep security-audit scans on PRs and pushes to main
- Uploads SARIF results to GitHub Code Scanning
- Comments findings on PRs with severity-grouped output, updating existing bot comments via an HTML marker
- Enforces a security gate that blocks merges when critical/high issues are found
- Uses find-update-or-create pattern for bot comments to avoid comment spam on repeated pushes

## Why

Replaces the previous CodeQL-only approach with Semgrep for broader rule coverage and simpler configuration. Provides inline PR feedback to catch security issues early in the review cycle.
