### PR TITLE
chore/git hooks adjustment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - repo: git@github.com:astral-sh/ruff-pre-commit.git
     rev: v0.14.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--config=pyproject.toml"]
       - id: ruff-format
         args: ["--config=pyproject.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
   - repo: git@github.com:astral-sh/ruff-pre-commit.git
     rev: v0.14.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,9 +35,9 @@ repos:
         always_run: true
         stages: [pre-push]
 
-      - id: prevent-mkdocs-yml-change
-        name: Prevent committing modified mkdocs.yml
-        entry: bash -c 'git diff --cached --name-only | grep -q "^mkdocs.yml$" && { echo "[ERROR] mkdocs.yml changes are not allowed to be committed!"; exit 1; } || exit 0'
+      - id: prevent-generated-mkdocs-nav
+        name: Block generated autodoc nav in mkdocs.yml
+        entry: "bash -c 'git show :mkdocs.yml 2>/dev/null | grep -q reference/autodoc && { echo \"[ERROR] mkdocs.yml contains generated autodoc nav (reference/autodoc). Restore via git show HEAD:mkdocs.yml > mkdocs.yml\"; exit 1; } || exit 0'"
         language: system
-        types: [file]
+        pass_filenames: false
         files: ^mkdocs\.yml$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,21 +83,16 @@ If a change affects public behavior, documentation updates are expected.
 1. **Fork the repository**
 2. **Clone your fork**: `git clone https://github.com/<username>/forging-blocks.git`
 3. **Install dependencies**: `poetry install`
-4. **Set up pre-commit hooks**: `pre-commit install`
+4. **Set up git hooks**: `poetry run pre-commit install`
 
+That single install enables both **pre-commit** and **pre-push** hooks (`default_install_hook_types` in `.pre-commit-config.yaml`).
 
 ### Automation Hooks
 
 The project uses `pre-commit` to automate quality checks.
 
-- **Pre-commit (Linting):** Runs on every commit. It checks for code style, trailing whitespace, and common errors. It is designed to be fast.
-- **Pre-push (Pipeline):** Runs on every push. It executes the full pipeline (`poetry run poe ci:simulate`), including type checking, all tests, and security scanning, to ensure the remote branch remains stable.
-
-To install both:
-```bash
-pre-commit install
-pre-commit install --hook-type pre-push
-```
+- **Pre-commit (Linting):** Runs on every commit. Fast checks: Ruff lint/format, trailing whitespace, YAML/TOML, and blocks committing a *generated* autodoc section in `mkdocs.yml` (paths under `reference/autodoc`). Hand-edited `mkdocs.yml` nav is allowed.
+- **Pre-push (Pipeline):** Runs on every push. Full pipeline (`poetry run poe ci:simulate`): type checking, tests, security scan, package check, and docs sync — keeps the remote branch stable.
 
 ### Making Changes
 


### PR DESCRIPTION
- **chore(pre-commit): install pre-commit and pre-push by default**
- **chore(pre-commit): rename ruff hook to ruff-check**
- **fix(pre-commit): block only generated autodoc nav in mkdocs.yml**
- **docs(contributing): document single-step hook install**
