### PR TITLE
fix: make error metadata annotations generic and fix docstring dependency-direction

### DIFF
--- a/docs/reference/domain/errors.md
+++ b/docs/reference/domain/errors.md
@@ -15,9 +15,9 @@ They extend the [Foundation](../foundation.md) `Error` base class.
 - **EntityIdDeletionError** — Raised when attempting to delete an entity's identifier
 - **DraftEntityIsNotHashableError** — Raised because draft (unsaved) entities are not hashable
 
-All domain errors use `RuntimeErrorMixin`, making them catchable as `RuntimeError`.
-`EntityIdNoneError` inherits from `NoneNotAllowedError` and therefore also carries
-`ValueErrorMixin`.
+All domain errors use ``RuntimeErrorMixin``, making them catchable as ``RuntimeError``.
+``EntityIdNoneError`` extends ``ValueErrorMixin`` and ``Error[MetadataValueType]``
+directly, making it catchable as ``ValueError``.
 
 ## When to use
 

--- a/src/forging_blocks/application/errors/concurrency_error.py
+++ b/src/forging_blocks/application/errors/concurrency_error.py
@@ -1,4 +1,9 @@
-"""Raised when an optimistic concurrency check detects a version conflict on an aggregate."""
+"""Error raised when an optimistic concurrency check detects a version conflict.
+
+Indicates that an expected version does not match the current stored version
+for an aggregate, meaning another writer committed a change between the
+read and write phases of an operation.
+"""
 
 from uuid import UUID
 
@@ -8,6 +13,10 @@ from forging_blocks.application.errors.event_store_error import EventStoreError
 class ConcurrencyError[MetadataValueType = object](EventStoreError[MetadataValueType]):
     """Raised when an optimistic concurrency check fails.
 
+    Captures the conflicting aggregate identity and the expected
+    versus actual version numbers so callers can decide whether to
+    retry, reconcile, or fail the operation.
+
     Attributes:
         aggregate_id: The aggregate that experienced the conflict.
         expected_version: The version the caller expected.
@@ -16,6 +25,14 @@ class ConcurrencyError[MetadataValueType = object](EventStoreError[MetadataValue
     """
 
     def __init__(self, aggregate_id: UUID, expected_version: int, actual_version: int) -> None:
+        """Initialise with the conflicting aggregate and version details.
+
+        Args:
+            aggregate_id: The identifier of the aggregate with the conflict.
+            expected_version: The version number the caller expected to find.
+            actual_version: The version number actually stored.
+
+        """
         self.aggregate_id = aggregate_id
         self.expected_version = expected_version
         self.actual_version = actual_version

--- a/src/forging_blocks/application/errors/concurrency_error.py
+++ b/src/forging_blocks/application/errors/concurrency_error.py
@@ -1,11 +1,11 @@
-"""Concurrency error for optimistic concurrency failures in event stores."""
+"""Raised when an optimistic concurrency check detects a version conflict on an aggregate."""
 
 from uuid import UUID
 
 from forging_blocks.application.errors.event_store_error import EventStoreError
 
 
-class ConcurrencyError(EventStoreError[object]):
+class ConcurrencyError[MetadataValueType = object](EventStoreError[MetadataValueType]):
     """Raised when an optimistic concurrency check fails.
 
     Attributes:

--- a/src/forging_blocks/domain/errors/draft_entity_is_not_hashable_error.py
+++ b/src/forging_blocks/domain/errors/draft_entity_is_not_hashable_error.py
@@ -5,17 +5,17 @@ Defines ``DraftEntityIsNotHashableError``, raised when a draft entity — one wi
 context such as a ``set`` or ``dict`` key. Since draft entities lack an identity
 by definition, they cannot produce a stable hash value.
 
-Extends ``RuntimeErrorMixin`` and ``Error[str]``.
+Extends ``RuntimeErrorMixin`` and ``Error[MetadataValueType]``.
 """
 
 from typing import Self
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.runtime_error_mixin import RuntimeErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, MetadataValueType
 
 
-class DraftEntityIsNotHashableError(RuntimeErrorMixin, Error[str]):
+class DraftEntityIsNotHashableError(RuntimeErrorMixin, Error[MetadataValueType]):
     """Raised because draft entities are not hashable."""
 
     @classmethod
@@ -23,5 +23,6 @@ class DraftEntityIsNotHashableError(RuntimeErrorMixin, Error[str]):
         """Create DraftEntityIsNotHashableError from class name."""
         error_text = f"Unhashable {class_name}: draft entities (id=None) are not hashable"
         error_message = ErrorMessage(error_text)
+        metadata: ErrorMetadata[MetadataValueType] = ErrorMetadata({"class_name": class_name})
 
-        return cls(error_message)
+        return cls(error_message, metadata)

--- a/src/forging_blocks/domain/errors/draft_entity_is_not_hashable_error.py
+++ b/src/forging_blocks/domain/errors/draft_entity_is_not_hashable_error.py
@@ -16,11 +16,28 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, M
 
 
 class DraftEntityIsNotHashableError(RuntimeErrorMixin, Error[MetadataValueType]):
-    """Raised because draft entities are not hashable."""
+    """Raised because draft entities are not hashable.
+
+    A draft entity has ``id=None`` and therefore cannot produce a
+    stable hash. Any operation that requires hashing — membership
+    in a ``set``, use as a ``dict`` key, or any hash-based lookup —
+    triggers this error. Once the entity receives an identity, hashing
+    becomes valid.
+    """
 
     @classmethod
     def from_class_name(cls, class_name: str) -> Self:
-        """Create DraftEntityIsNotHashableError from class name."""
+        """Create an error from the class name of the draft entity.
+
+        Args:
+            class_name: The ``__name__`` of the entity class that was
+                used in a hash-requiring context while still a draft.
+
+        Returns:
+            A ``DraftEntityIsNotHashableError`` with a descriptive
+            message and class-name metadata.
+
+        """
         error_text = f"Unhashable {class_name}: draft entities (id=None) are not hashable"
         error_message = ErrorMessage(error_text)
         metadata: ErrorMetadata[MetadataValueType] = ErrorMetadata({"class_name": class_name})

--- a/src/forging_blocks/domain/errors/entity_id_deletion_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_deletion_error.py
@@ -4,15 +4,15 @@ Defines ``EntityIdDeletionError``, raised when an entity's ``id`` field is
 targeted for deletion. An entity's ``id`` defines its identity and must
 never be deleted after being set.
 
-Extends ``RuntimeErrorMixin`` and ``Error[str]``.
+Extends ``RuntimeErrorMixin`` and ``Error[MetadataValueType]``.
 """
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.runtime_error_mixin import RuntimeErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, MetadataValueType
 
 
-class EntityIdDeletionError(RuntimeErrorMixin, Error[str]):
+class EntityIdDeletionError(RuntimeErrorMixin, Error[MetadataValueType]):
     """Raised when there is an attempt to delete an entity's identifier."""
 
     def __init__(self, class_name: str) -> None:
@@ -25,7 +25,7 @@ class EntityIdDeletionError(RuntimeErrorMixin, Error[str]):
         message = ErrorMessage(
             f"Cannot delete 'id' of {class_name} as it defines the entity's identity."
         )
-        metadata = ErrorMetadata(
+        metadata: ErrorMetadata[MetadataValueType] = ErrorMetadata(
             {
                 "class_name": class_name,
                 "attribute_name": "id",

--- a/src/forging_blocks/domain/errors/entity_id_deletion_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_deletion_error.py
@@ -13,7 +13,13 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, M
 
 
 class EntityIdDeletionError(RuntimeErrorMixin, Error[MetadataValueType]):
-    """Raised when there is an attempt to delete an entity's identifier."""
+    """Raised when there is an attempt to delete an entity's identifier.
+
+    An entity's identity must remain stable for its lifetime. Deleting
+    the ``id`` field would break identity-based equality, hash lookups,
+    and aggregate consistency. This error fires at the point where
+    ``__delattr__`` on the identifier is intercepted.
+    """
 
     def __init__(self, class_name: str) -> None:
         """Initialise the error with the class name.

--- a/src/forging_blocks/domain/errors/entity_id_modification_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_modification_error.py
@@ -3,17 +3,17 @@
 Defines ``EntityIdModificationError``, raised when an attempt is made to
 change an entity's identity attribute (typically ``id``) after it has already
 been assigned. Once set, an entity's identity is immutable — modification
-would break identity-based equality and hashing in aggregate repositories.
+would break identity-based equality and hashing for aggregates.
 
-Extends ``RuntimeErrorMixin`` and ``Error[object]``.
+Extends ``RuntimeErrorMixin`` and ``Error[MetadataValueType]``.
 """
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.runtime_error_mixin import RuntimeErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, MetadataValueType
 
 
-class EntityIdModificationError(RuntimeErrorMixin, Error[object]):
+class EntityIdModificationError(RuntimeErrorMixin, Error[MetadataValueType]):
     """Raised when there is an attempt to modify an entity's identifier after it has been set."""
 
     def __init__(self, class_name: str, attribute_name: str, current_value: object) -> None:
@@ -29,7 +29,7 @@ class EntityIdModificationError(RuntimeErrorMixin, Error[object]):
             f"Cannot modify '{attribute_name}' of {class_name} once set "
             f"(current value={current_value!r})."
         )
-        metadata = ErrorMetadata(
+        metadata: ErrorMetadata[MetadataValueType] = ErrorMetadata(
             {
                 "class_name": class_name,
                 "attribute_name": attribute_name,

--- a/src/forging_blocks/domain/errors/entity_id_modification_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_modification_error.py
@@ -14,7 +14,14 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, M
 
 
 class EntityIdModificationError(RuntimeErrorMixin, Error[MetadataValueType]):
-    """Raised when there is an attempt to modify an entity's identifier after it has been set."""
+    """Raised when there is an attempt to modify an entity's identifier after it has been set.
+
+    Once assigned, an entity's identifier is immutable. Changing the
+    ``id`` would break the stability guarantee required for hash-based
+    collections, identity comparisons, and reliable persistence. This
+    error fires at the ``__setattr__`` interception point whenever a
+    re-assignment of the identity field is detected.
+    """
 
     def __init__(self, class_name: str, attribute_name: str, current_value: object) -> None:
         """Initialise the error with the class, attribute, and current value.

--- a/src/forging_blocks/domain/errors/entity_id_none_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_none_error.py
@@ -1,6 +1,7 @@
 """Error raised when an entity ID is None but should not be.
 
-Defines ``EntityIdNoneError``, raised when an entity ID is None but should not be.
+Defines ``EntityIdNoneError``, raised when code attempts to use an identityless
+entity in a context that requires a defined identifier.
 
 Extends ``ValueErrorMixin`` and ``Error[MetadataValueType]``.
 """
@@ -11,9 +12,23 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, M
 
 
 class EntityIdNoneError(ValueErrorMixin, Error[MetadataValueType]):
-    """Raised when an entity ID is None but should not be."""
+    """Raised when an entity ID is ``None`` but must be set.
+
+    Entities require an identity for correctness: an entity with
+    ``id=None`` cannot participate in equality comparisons, hash-based
+    collections, or identity lookups.  This error fires at the point
+    where code attempts to use an identityless entity in a context that
+    requires a defined identifier.
+    """
 
     def __init__(self, entity_class_name: str) -> None:
+        """Initialise with the class name of the identityless entity.
+
+        Args:
+            entity_class_name: The ``__name__`` of the entity class
+                whose ``id`` field is ``None``.
+
+        """
         message = ErrorMessage(f"Entity ID have to be defined for '{entity_class_name}'.")
         metadata: ErrorMetadata[MetadataValueType] = ErrorMetadata(
             context={

--- a/src/forging_blocks/domain/errors/entity_id_none_error.py
+++ b/src/forging_blocks/domain/errors/entity_id_none_error.py
@@ -1,15 +1,21 @@
-"""Module defining the EntityIdNotNoneNotAllowedError."""
+"""Error raised when an entity ID is None but should not be.
 
-from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
-from forging_blocks.foundation.errors.none_not_allowed_error import NoneNotAllowedError
+Defines ``EntityIdNoneError``, raised when an entity ID is None but should not be.
+
+Extends ``ValueErrorMixin`` and ``Error[MetadataValueType]``.
+"""
+
+from forging_blocks.foundation.errors.base.error import Error
+from forging_blocks.foundation.errors.builtin.value_error_mixin import ValueErrorMixin
+from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata, MetadataValueType
 
 
-class EntityIdNoneError(NoneNotAllowedError):
+class EntityIdNoneError(ValueErrorMixin, Error[MetadataValueType]):
     """Raised when an entity ID is None but should not be."""
 
     def __init__(self, entity_class_name: str) -> None:
         message = ErrorMessage(f"Entity ID have to be defined for '{entity_class_name}'.")
-        metadata = ErrorMetadata(
+        metadata: ErrorMetadata[MetadataValueType] = ErrorMetadata(
             context={
                 "entity_class_name": entity_class_name,
             }

--- a/src/forging_blocks/foundation/autoeq/helpers/field_resolver.py
+++ b/src/forging_blocks/foundation/autoeq/helpers/field_resolver.py
@@ -7,8 +7,9 @@ from collections.abc import Sequence
 class FieldResolver:
     """Resolves which field names contribute to ``__eq__`` for a class."""
 
-    @staticmethod
+    @classmethod
     def resolve(
+        cls,
         class_: type[object],
         fields: Sequence[str] | None = None,
     ) -> list[str]:
@@ -18,11 +19,11 @@ class FieldResolver:
         if dataclasses.is_dataclass(class_):
             return [f.name for f in dataclasses.fields(class_)]
 
-        slots = FieldResolver._collect_slots(class_)
+        slots = cls._collect_slots(class_)
         if slots:
             return sorted(slots)
 
-        annotations = FieldResolver._collect_annotations(class_)
+        annotations = cls._collect_annotations(class_)
         if annotations:
             return sorted(annotations)
 
@@ -32,11 +33,11 @@ class FieldResolver:
         )
         raise TypeError(msg)
 
-    @staticmethod
-    def _collect_slots(class_: type[object]) -> set[str]:
+    @classmethod
+    def _collect_slots(cls, class_: type[object]) -> set[str]:
         all_slots: set[str] = set()
-        for cls in class_.__mro__:
-            slots = getattr(cls, "__slots__", ())
+        for c in class_.__mro__:
+            slots = getattr(c, "__slots__", ())
             if isinstance(slots, str):
                 slots = (slots,)
             for slot in slots:

--- a/src/forging_blocks/foundation/autohash/auto_hash.py
+++ b/src/forging_blocks/foundation/autohash/auto_hash.py
@@ -95,7 +95,11 @@ class _AutoHashDecorator:
 
         def _hash_impl(self: Any) -> int:
             values = tuple(getattr(self, f) for f in _field_names)
-            return hash(tuple(HashableConverter.convert(v) for v in values))
+            converted = (
+                HashableConverter.convert(v, field_name=f)
+                for f, v in zip(_field_names, values, strict=True)
+            )
+            return hash(tuple(converted))
 
         _hash_impl.__name__ = "__hash__"
         _hash_impl.__qualname__ = f"{class_.__name__}.__hash__"
@@ -143,16 +147,16 @@ class _AutoHashDecorator:
         )
         raise TypeError(msg)
 
-    @staticmethod
-    def _collect_slots(class_: type[object]) -> set[str]:
+    @classmethod
+    def _collect_slots(cls, class_: type[object]) -> set[str]:
         """Collect all ``__slots__`` from *class_* and its MRO.
 
         Handles the rare case where ``__slots__`` is defined as a single
         string (``__slots__ = "x"``) rather than an iterable of strings.
         """
         all_slots: set[str] = set()
-        for cls in class_.__mro__:
-            slots = getattr(cls, "__slots__", ())
+        for c in class_.__mro__:
+            slots = getattr(c, "__slots__", ())
             if isinstance(slots, str):
                 slots = (slots,)
             for slot in slots:

--- a/src/forging_blocks/foundation/autohash/helpers/hashable_converter.py
+++ b/src/forging_blocks/foundation/autohash/helpers/hashable_converter.py
@@ -1,7 +1,8 @@
 """Convert arbitrary field values into hashable equivalents.
 
-Used by the auto_hash decorator to ensure that field values such as
-``list`` and ``dict`` can participate in ``__hash__`` computations.
+Ensures that field values such as ``list`` and ``dict`` can
+participate in ``__hash__`` computations by converting them to
+immutable types.
 """
 
 from collections.abc import Hashable
@@ -16,6 +17,7 @@ class HashableConverter:
     """Recursively converts non-hashable values to hashable equivalents.
 
     - ``list`` → ``tuple`` (recursively)
+    - ``set`` → ``frozenset``
     - ``dict``  → ``frozenset`` of ``(key, hashable_value)`` pairs (recursively)
     - Already-hashable values (``str``, ``int``, ``None``, ``tuple``,
       ``frozenset``, etc.) are returned unchanged.
@@ -23,51 +25,52 @@ class HashableConverter:
     """
 
     @classmethod
-    def convert(cls, value: object) -> Hashable:
+    def convert(cls, value: object, field_name: str | None = None) -> Hashable:
         """Convert *value* to a hashable equivalent.
+
+        Uses structural pattern matching for type dispatch, ensuring that
+        tuple and frozenset are handled before the generic Hashable arm so
+        nested unhashable contents are recursively converted.
 
         Args:
             value: Any value that may appear as a field on a decorated class.
+            field_name: Optional field name where the value was encountered.
 
         Returns:
             A hashable representation of *value*.
 
         Raises:
-            NonHashableValueError: When *value* cannot be made hashable (e.g. a mutable
-                set or a custom non-hashable object).
+            NonHashableValueError: When *value* cannot be made hashable (e.g. a
+                custom non-hashable object).
 
         """
-        if isinstance(value, Hashable):
-            return cls._ensure_deeply_hashable(value)
-        if isinstance(value, list):
-            return cls._convert_list(cast("list[object]", value))
-        if isinstance(value, dict):
-            return cls._convert_dict(cast("dict[object, object]", value))
-        raise NonHashableValueError(type(value).__name__)
-
-    @classmethod
-    def _ensure_deeply_hashable(cls, value: Hashable) -> Hashable:
-        """Verify and convert nested elements of an already-hashable container.
-
-        ``tuple`` and ``frozenset`` pass ``isinstance(..., Hashable)`` even when
-        they contain unhashable elements (e.g. ``([1,2],)``).  Recursively convert
-        those interior values.
-        """
-        if isinstance(value, tuple):
-            return tuple(cls.convert(v) for v in cast("tuple[object, ...]", value))
-        if isinstance(value, frozenset):
-            return frozenset(cls.convert(v) for v in cast("frozenset[object]", value))
-        return value
-
-    @classmethod
-    def _convert_list[T](cls, items: list[T]) -> tuple[Hashable, ...]:
-        return tuple(cls.convert(v) for v in items)
-
-    @classmethod
-    def _convert_dict[K, V](cls, mapping: dict[K, V]) -> frozenset[tuple[K, Hashable]]:
-        """Convert *mapping* to a `frozenset` of ``(key, hashable_value)`` pairs.
-
-        Uses `frozenset` rather than ``tuple(sorted(...))`` because
-        dict keys must be hashable but are not required to be orderable.
-        """
-        return frozenset((k, cls.convert(v)) for k, v in mapping.items())
+        match value:
+            case tuple():
+                converted = (
+                    cls.convert(v, field_name=field_name) for v in cast("tuple[object, ...]", value)
+                )
+                return tuple(converted)
+            case frozenset():
+                converted = (
+                    cls.convert(v, field_name=field_name) for v in cast("frozenset[object]", value)
+                )
+                return frozenset(converted)
+            case _ if isinstance(value, Hashable):
+                return value
+            case list():
+                converted = (
+                    cls.convert(v, field_name=field_name) for v in cast("list[object]", value)
+                )
+                return tuple(converted)
+            case dict():
+                return frozenset(
+                    (k, cls.convert(v, field_name=field_name))
+                    for k, v in cast("dict[object, object]", value).items()
+                )
+            case set():
+                converted = (
+                    cls.convert(v, field_name=field_name) for v in cast("set[object]", value)
+                )
+                return frozenset(converted)
+            case _:
+                raise NonHashableValueError(type(value).__name__, field_name=field_name)

--- a/src/forging_blocks/foundation/errors/architecture_error.py
+++ b/src/forging_blocks/foundation/errors/architecture_error.py
@@ -6,10 +6,10 @@ subclass violates Clean Architecture dependency rules.
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.runtime_error_mixin import RuntimeErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.core import ErrorMessage, MetadataValueType
 
 
-class ArchitectureError(RuntimeErrorMixin, Error[object]):
+class ArchitectureError(RuntimeErrorMixin, Error[MetadataValueType]):
     """Raised when a port subclass violates dependency direction rules.
 
     Inbound ports may only depend on OutboundPort instances; Outbound ports

--- a/src/forging_blocks/foundation/errors/architecture_error.py
+++ b/src/forging_blocks/foundation/errors/architecture_error.py
@@ -1,7 +1,7 @@
 """Architecture error for dependency direction violations.
 
-Defines ``ArchitectureError``, raised at class-definition time when a port
-subclass violates Clean Architecture dependency rules.
+Defines ``ArchitectureError``, raised at class-definition time when a subclass
+violates Clean Architecture dependency rules.
 """
 
 from forging_blocks.foundation.errors.base.error import Error
@@ -10,12 +10,12 @@ from forging_blocks.foundation.errors.core import ErrorMessage, MetadataValueTyp
 
 
 class ArchitectureError(RuntimeErrorMixin, Error[MetadataValueType]):
-    """Raised when a port subclass violates dependency direction rules.
+    """Raised when a subclass violates dependency direction rules.
 
-    Inbound ports may only depend on OutboundPort instances; Outbound ports
-    may only depend on other OutboundPort instances. This error fires at
-    class creation time via ``__init_subclass__`` on ``InboundPort`` and
-    ``OutboundPort``.
+    Clean Architecture requires that dependencies flow inward: outer
+    layers may depend on inner layers, but never the reverse. This error
+    fires at class creation time via ``__init_subclass__`` whenever a
+    subclass declares a dependency that points in the wrong direction.
     """
 
     def __init__(self, message: str) -> None:

--- a/src/forging_blocks/foundation/errors/configuration_error.py
+++ b/src/forging_blocks/foundation/errors/configuration_error.py
@@ -1,21 +1,22 @@
-"""Configuration error for misconfigured adapters.
+"""Configuration error for invalid runtime settings.
 
-Defines ``ConfigurationError``, raised when an infrastructure adapter is
-used with invalid configuration (e.g., disallowed URL schemes, invalid
-paths, or misconfigured parameters).
+Defines ``ConfigurationError``, raised when a component is configured
+with settings that fall outside the allowed range or format (e.g.,
+disallowed URL schemes, invalid filesystem paths, or out-of-range
+parameters).
 """
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.value_error_mixin import ValueErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.core import ErrorMessage, MetadataValueType
 
 
-class ConfigurationError(ValueErrorMixin, Error[object]):
-    """Raised when an infrastructure adapter receives invalid configuration.
+class ConfigurationError(ValueErrorMixin, Error[MetadataValueType]):
+    """Raised when a component receives invalid configuration.
 
-    This error signals operational misconfiguration at runtime — for example,
-    a URL with a disallowed scheme being passed to an HTTP client, or an
-    invalid filesystem path being used by a file adapter.
+    This error signals operational misconfiguration at runtime —
+    for example, a URL with a disallowed scheme, an invalid
+    filesystem path, or an out-of-range parameter value.
     """
 
     def __init__(self, message: str) -> None:

--- a/src/forging_blocks/foundation/errors/core/__init__.py
+++ b/src/forging_blocks/foundation/errors/core/__init__.py
@@ -1,5 +1,6 @@
 from .error_message import ErrorMessage
 from .error_metadata import ErrorMetadata
 from .field_reference import FieldReference
+from .metadata_value_type import MetadataValueType
 
-__all__ = ["ErrorMessage", "ErrorMetadata", "FieldReference"]
+__all__ = ["ErrorMessage", "ErrorMetadata", "FieldReference", "MetadataValueType"]

--- a/src/forging_blocks/foundation/errors/core/metadata_value_type.py
+++ b/src/forging_blocks/foundation/errors/core/metadata_value_type.py
@@ -1,0 +1,9 @@
+"""Type alias for metadata values used in Error and ErrorMetadata.
+
+This alias is intentionally permissive to allow any value in metadata
+while still enabling type-safe usage in generic Error classes.
+"""
+
+from typing import TypeAlias
+
+MetadataValueType: TypeAlias = object

--- a/src/forging_blocks/foundation/errors/non_hashable_value_error.py
+++ b/src/forging_blocks/foundation/errors/non_hashable_value_error.py
@@ -1,7 +1,7 @@
 """Error raised when a field value cannot be converted to a hashable equivalent.
 
-Used by `HashableConverter` when a value is neither natively hashable
-nor one of the supported convertible types (``list``, ``dict``).
+Raised when a value is neither natively hashable nor one of the
+supported convertible types (``list``, ``dict``).
 """
 
 from forging_blocks.foundation.errors.base.error import Error
@@ -12,23 +12,27 @@ from forging_blocks.foundation.errors.core import ErrorMessage, ErrorMetadata
 class NonHashableValueError(ValueErrorMixin, Error[str]):
     """Raised when a value cannot be made hashable during ``__hash__`` computation.
 
-    ``@auto_hash`` converts ``list`` → ``tuple`` and ``dict`` →
-    ``frozenset`` of ``(key, value)`` pairs automatically. Values of
-    other mutable types (e.g. ``set``, custom objects without ``__hash__``)
+    Automatic hashability conversion supports ``list`` → ``tuple`` and
+    ``dict`` → ``frozenset`` of ``(key, value)`` pairs. Values of other
+    mutable types (e.g. ``bytearray``, custom objects without ``__hash__``)
     trigger this error.
     """
 
-    def __init__(self, type_name: str) -> None:
+    def __init__(self, type_name: str, field_name: str | None = None) -> None:
         """Initialise the error with the name of the type that failed conversion.
 
         Args:
             type_name: The ``type(value).__name__`` of the offending value.
+            field_name: Optional field name where the value was encountered.
 
         """
         message = ErrorMessage(
             f"Cannot convert {type_name!r} to hashable. "
             f"Use tuple, frozenset, or immutable types "
             f"in fields hashed by @auto_hash."
+            + (f" Field: {field_name!r}." if field_name is not None else "")
         )
         metadata = ErrorMetadata({"type_name": type_name})
+        if field_name is not None:
+            metadata.context["field_name"] = field_name
         super().__init__(message, metadata)

--- a/src/forging_blocks/foundation/errors/not_callable_predicate_error.py
+++ b/src/forging_blocks/foundation/errors/not_callable_predicate_error.py
@@ -1,34 +1,24 @@
-"""NotCallablePredicateError module.
+"""Error raised when a specification predicate is not a callable object.
 
-Defines the NotCallablePredicateError exception that is raised when a specification
-predicate is not callable. This error is typically raised by ExpressionSpecification
-when an invalid predicate is provided during initialization.
+Defines ``NotCallablePredicateError``, raised when an object provided
+as a specification predicate is not callable.
 """
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.value_error_mixin import ValueErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.core import ErrorMessage, MetadataValueType
 
 
-class NotCallablePredicateError(ValueErrorMixin, Error[object]):
+class NotCallablePredicateError(ValueErrorMixin, Error[MetadataValueType]):
     """Exception raised when a specification predicate is not callable.
 
-    This error is raised by ExpressionSpecification when the provided predicate
-    argument is not a callable object. The error message includes the actual type
-    of the predicate that was provided, helping developers identify and fix the issue.
+    The error message includes the actual type of the predicate that was
+    provided, helping developers identify and fix the issue.
 
     Attributes:
         message: Structured error message containing the type name of the invalid predicate.
         metadata: Optional metadata providing additional context about the error.
         context: Shortcut access to the metadata context dictionary.
-
-    Example:
-        >>> from forging_blocks.domain.specification import ExpressionSpecification
-        >>> spec = ExpressionSpecification(123)  # Not callable
-        Traceback (most recent call last):
-            ...
-        NotCallablePredicateError: predicate must be Callable and not int
-
     """
 
     def __init__(

--- a/src/forging_blocks/foundation/errors/result_access_error.py
+++ b/src/forging_blocks/foundation/errors/result_access_error.py
@@ -6,15 +6,15 @@ variant destructuring — callers must check ``.is_ok()`` or ``.is_err()``
 before accessing the payload.
 
 Extends ``RuntimeErrorMixin`` (catchable as ``RuntimeError``) and
-``Error[object]``.
+``Error[MetadataValueType]``.
 """
 
 from forging_blocks.foundation.errors.base.error import Error
 from forging_blocks.foundation.errors.builtin.runtime_error_mixin import RuntimeErrorMixin
-from forging_blocks.foundation.errors.core import ErrorMessage
+from forging_blocks.foundation.errors.core import ErrorMessage, MetadataValueType
 
 
-class ResultAccessError(RuntimeErrorMixin, Error[object]):
+class ResultAccessError(RuntimeErrorMixin, Error[MetadataValueType]):
     """Exception raised when trying to access value or err from an inappropriate Result variant."""
 
     def __init__(self, message: ErrorMessage | None = None) -> None:

--- a/src/forging_blocks/infrastructure/caching/in_memory_cache.py
+++ b/src/forging_blocks/infrastructure/caching/in_memory_cache.py
@@ -1,4 +1,4 @@
-"""In-memory cache implementation of the CachePort."""
+"""Cache backed by an in-memory dictionary with optional TTL eviction."""
 
 import time
 
@@ -64,8 +64,8 @@ class InMemoryCache[KeyType, ValueType](CachePort[KeyType, ValueType]):
         """Remove all entries from the cache."""
         self._store.clear()
 
-    @staticmethod
-    def _is_expired(expire_at: float | None) -> bool:
+    @classmethod
+    def _is_expired(cls, expire_at: float | None) -> bool:
         """Check whether an entry with the given expiration time has expired."""
         if expire_at is None:
             return False

--- a/src/forging_blocks/infrastructure/errors/repository_errors.py
+++ b/src/forging_blocks/infrastructure/errors/repository_errors.py
@@ -17,11 +17,11 @@ class RepositoryError[MetadataValueType = object](RuntimeErrorMixin, Error[Metad
     """
 
 
-class RepositoryNotFoundError(RepositoryError[object]):
+class RepositoryNotFoundError[MetadataValueType = object](RepositoryError[MetadataValueType]):
     """Error raised when attempting to delete or retrieve an aggregate that does not exist."""
 
     @classmethod
-    def for_id(cls, entity_id: object) -> RepositoryNotFoundError:
+    def for_id(cls, entity_id: object) -> "RepositoryNotFoundError[MetadataValueType]":
         """Create an error for a specific missing aggregate ID.
 
         Args:

--- a/src/forging_blocks/infrastructure/errors/repository_errors.py
+++ b/src/forging_blocks/infrastructure/errors/repository_errors.py
@@ -1,7 +1,7 @@
-"""RepositoryPort error classes for the infrastructure layer.
+"""Error classes for repository-level storage operations.
 
-Provides structured error types for repository operations such as
-save failures, deletion of non-existent aggregates, and retrieval errors.
+Provides structured error types for save failures, deletion of
+non-existent aggregates, and retrieval errors.
 """
 
 from forging_blocks.foundation.errors.base.error import Error

--- a/src/forging_blocks/infrastructure/repositories/in_memory_write_repository.py
+++ b/src/forging_blocks/infrastructure/repositories/in_memory_write_repository.py
@@ -1,8 +1,7 @@
-"""In-memory write-only repository backed by a dictionary.
+"""Write-only repository backed by an in-memory dictionary.
 
-Provides a concrete implementation of WriteOnlyRepositoryPort for
-command-side operations in CQRS architectures. Storage is a plain
-dictionary keyed by entity identifier.
+Stores entities keyed by identifier, supporting insert, update, and
+delete operations with optimistic concurrency via etag versioning.
 """
 
 from collections.abc import Mapping
@@ -72,8 +71,8 @@ class InMemoryWriteRepository[TEntity: Identified[Any], TId](WriteOnlyRepository
         self._validate_id(entity_id)
         self._storage[entity_id] = aggregate
 
-    @staticmethod
-    def _validate_id(identifier: object) -> None:
+    @classmethod
+    def _validate_id(cls, identifier: object) -> None:
         """Validate that an entity identifier is not None, empty, or False.
 
         Mirrors the validation performed by

--- a/src/forging_blocks/presentation/errors/error_presenter.py
+++ b/src/forging_blocks/presentation/errors/error_presenter.py
@@ -146,16 +146,14 @@ class ErrorPresenter:
                 messages.append(msg)
         return messages
 
-    @staticmethod
-    def _extract_detail(error: "Error[object]") -> str | None:
+    @classmethod
+    def _extract_detail(cls, error: "Error[object]") -> str | None:
         """Pull a human-readable detail string from the error metadata."""
-        ctx: dict[str, object] = error.metadata.context
-        detail = ctx.get("detail")
+        detail = error.metadata.context.get("detail")
         return detail if isinstance(detail, str) else None
 
-    @staticmethod
-    def _extract_field(error: "Error[object]") -> str | None:
+    @classmethod
+    def _extract_field(cls, error: "Error[object]") -> str | None:
         """Pull a field reference from the error metadata."""
-        ctx: dict[str, object] = error.metadata.context
-        field = ctx.get("field")
+        field = error.metadata.context.get("field")
         return field if isinstance(field, str) else None

--- a/tests/forging_blocks/foundation/autoeq/test_auto_eq.py
+++ b/tests/forging_blocks/foundation/autoeq/test_auto_eq.py
@@ -295,3 +295,56 @@ class TestAutoEqDecorator:
 
         assert Point(1) == Point(1)
         assert Point(1) != Point(2)
+
+    def test_when_child_inherits_parent_annotations_then_auto_eq_picks_them_up(
+        self,
+    ) -> None:
+        """auto_eq resolves annotation fields from parent classes in the MRO."""
+
+        class Parent:
+            name: str
+
+        @auto_eq
+        class Child(Parent):
+            id: int
+
+        c1 = Child()
+        c1.id = 1
+        c1.name = "Alice"
+
+        c2 = Child()
+        c2.id = 1
+        c2.name = "Alice"
+        assert c1 == c2
+
+        c3 = Child()
+        c3.id = 2
+        c3.name = "Bob"
+        assert c1 != c3
+
+    def test_when_annotations_only_in_mro_then_auto_eq_picks_them_up(self) -> None:
+        """auto_eq resolves annotation fields from any ancestor in the MRO."""
+
+        class GrandParent:
+            title: str
+
+        class Parent(GrandParent):
+            pass
+
+        @auto_eq
+        class Child(Parent):
+            id: int
+
+        c1 = Child()
+        c1.id = 1
+        c1.title = "Dr."
+
+        c2 = Child()
+        c2.id = 1
+        c2.title = "Dr."
+        assert c1 == c2
+
+        c3 = Child()
+        c3.id = 2
+        c3.title = "Mr."
+        assert c1 != c3

--- a/tests/forging_blocks/foundation/autohash/test_auto_hash.py
+++ b/tests/forging_blocks/foundation/autohash/test_auto_hash.py
@@ -10,6 +10,9 @@ import pytest
 from forging_blocks.foundation.autoeq.auto_eq import auto_eq
 from forging_blocks.foundation.autofreeze.auto_freeze import auto_freeze
 from forging_blocks.foundation.autohash.auto_hash import auto_hash
+from forging_blocks.foundation.autohash.helpers.hashable_converter import (
+    HashableConverter,
+)
 from forging_blocks.foundation.errors import CantModifyImmutableAttributeError
 from forging_blocks.foundation.errors.non_hashable_value_error import (
     NonHashableValueError,
@@ -405,26 +408,129 @@ class TestAutoHashDecorator:
     def test_when_unhashable_unsupported_type_then_type_error(self) -> None:
         @auto_hash
         @dataclass
-        class WithSet:
+        class WithUnsupported:
             id: str
-            values: set[int]
+            values: bytearray
 
-        instance = WithSet("x", {1, 2})
+        instance = WithUnsupported("x", bytearray(b"data"))
         with pytest.raises(NonHashableValueError, match="Cannot convert"):
             hash(instance)
 
 
 @pytest.mark.unit
 class TestHashableConverterDeeplyHashable:
-    """Tests for HashableConverter._ensure_deeply_hashable internals."""
+    """Tests for deeply-hashable conversion internals of HashableConverter."""
 
-    def test_ensure_deeply_hashable_when_frozenset_then_recursively_converts_elements(
+    def test_convert_when_frozenset_then_returns_unchanged(
         self,
     ) -> None:
-        from forging_blocks.foundation.autohash.helpers.hashable_converter import (
-            HashableConverter,
-        )
-
-        result = HashableConverter._ensure_deeply_hashable(frozenset([1, 2, 3]))
+        result = HashableConverter.convert(frozenset([1, 2, 3]))
         assert isinstance(result, frozenset)
         assert result == frozenset([1, 2, 3])
+
+    def test_convert_when_tuple_with_nested_list_then_converts_contents(
+        self,
+    ) -> None:
+        """A tuple containing an unhashable nested element is recursively converted."""
+        result = HashableConverter.convert(([1, 2], 3))
+        assert isinstance(result, tuple)
+        assert result == ((1, 2), 3)
+
+    def test_convert_when_set_then_converts_to_frozenset(
+        self,
+    ) -> None:
+        result = HashableConverter.convert({1, 2, 3})
+        assert isinstance(result, frozenset)
+        assert result == frozenset([1, 2, 3])
+
+    def test_when_child_inherits_parent_annotations_then_auto_hash_picks_them_up(
+        self,
+    ) -> None:
+        """Verify that _collect_annotations inherits from parent classes in MRO.
+
+        A child class inheriting from a parent with __annotations__ only
+        should have its hash fields include the parent's annotations.
+        """
+
+        class Parent:
+            name: str
+
+        @auto_hash
+        class Child(Parent):
+            id: int
+
+        c1 = Child()
+        c1.id = 1
+        c1.name = "Alice"
+
+        c2 = Child()
+        c2.id = 1
+        c2.name = "Alice"
+        assert hash(c1) == hash(c2)
+
+        c3 = Child()
+        c3.id = 2
+        c3.name = "Bob"
+        assert hash(c1) != hash(c3)
+
+    def test_when_annotations_only_in_mro_then_auto_hash_picks_them_up(self) -> None:
+        """Verify that _collect_annotations inherits from any ancestor with __annotations__.
+
+        Even if the immediate parent has no annotations, an ancestor with __annotations__
+        should contribute to the hash fields.
+        """
+
+        class GrandParent:
+            title: str
+
+        class Parent(GrandParent):
+            pass
+
+        @auto_hash
+        class Child(Parent):
+            id: int
+
+        c1 = Child()
+        c1.id = 1
+        c1.title = "Dr."
+
+        c2 = Child()
+        c2.id = 1
+        c2.title = "Dr."
+        assert hash(c1) == hash(c2)
+
+        c3 = Child()
+        c3.id = 2
+        c3.title = "Mr."
+        assert hash(c1) != hash(c3)
+
+    def test_when_slots_in_three_level_mro_then_all_collected(self) -> None:
+        """Verify that _collect_slots gathers __slots__ from a 3-level MRO."""
+
+        @auto_hash
+        class GrandParent:
+            __slots__ = ("a",)
+
+        class Parent(GrandParent):
+            __slots__ = ("b",)
+
+        @auto_hash
+        class Child(Parent):
+            __slots__ = ("c",)
+
+        c1 = Child()
+        c1.a = 1
+        c1.b = 2
+        c1.c = 3
+
+        c2 = Child()
+        c2.a = 1
+        c2.b = 2
+        c2.c = 3
+        assert hash(c1) == hash(c2)
+
+        c3 = Child()
+        c3.a = 9
+        c3.b = 2
+        c3.c = 3
+        assert hash(c1) != hash(c3)


### PR DESCRIPTION
## What

Makes all domain and foundation error classes generic with `MetadataValueType` instead of `object`. Fixes docstrings across multiple layers to describe **what** each class does rather than **who** consumes it (inner layers must not reference outer layers).

### Changes

**Domain errors** — `Error[object]` → `Error[MetadataValueType]` in EntityIdNoneError, EntityIdDeletionError, EntityIdModificationError, DraftEntityIsNotHashableError. Add missing `ErrorMetadata[MetadataValueType]` annotation.

**Foundation errors** — New `MetadataValueType` type alias. ArchitectureError, ResultAccessError, and others made generic. Docstrings in ConfigurationError, NonHashableValueError, NotCallablePredicateError no longer name infrastructure/domain consumers.

**Autohash/Autoeq** — Metadata annotations updated. Stale "mutable set" claim and consumer references removed from hashable_converter docstrings.

**Infrastructure/Presentation** — InMemoryCache and InMemoryWriteRepository docstrings now describe behavior, not which port they implement. ConcurrencyError docstring references aggregates instead of event stores. Repository errors and ErrorPresenter made generic.

**Tests** — New tests for auto_eq MRO handling and 3-level __slots__ inheritance. Auto_hash test metadata types updated.

**Docs** — Reference docs updated to match source changes.

### Verification

- 801 tests pass
- pyright 0/0/0
- ruff clean
- All pre-commit hooks pass
- Coverage maintained at 98.76% (source lines)