### PR TITLE
chore/foundation docs improvement

### DIFF
--- a/docs/architectural-styles/layered-architecture.md
+++ b/docs/architectural-styles/layered-architecture.md
@@ -5,7 +5,8 @@ Layered Architecture organizes software into horizontal layers, each with a dist
 This page shows how **ForgingBlocks concepts can be projected** onto a traditional layered arrangement.
 
 !!! note "Important"
-
+    ForgingBlocks does **not** enforce Layered Architecture.
+    This page presents it as an **interpretation**, not a required structure.
 ---
 
 ## Quick summary

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -221,5 +221,5 @@ aggregated for reporting.
 Once you are comfortable with these examples, you can:
 
 - read [Principles](principles.md) to understand why the toolkit is structured this way,
-- map examples into blocks using [Recommended Blocks Structure](recommended_blocks_structure.md),
+- map examples into blocks using [Library Structure](library-structure.md),
 - and explore architectural mappings in the **Architectural Styles** section if you want to see how these ideas can appear inside well-known styles.

--- a/docs/guide/library-structure.md
+++ b/docs/guide/library-structure.md
@@ -1,13 +1,15 @@
-# Blocks Structure
+# Internal Block Structure
 ## How forging-blocks is organized internally
 
 This section describes how **forging-blocks itself** is structured into blocks — named groups of code sharing a responsibility and boundary. It documents the library's own internal organization, not a prescription for how you should structure your project.
 
-!!! warning "Foundation is not a canonical block name"
-    "Foundation" is the library's own term for its innermost, zero-dependency block.
-    Your own project's innermost block should carry a name meaningful to your domain —
-    `Core`, `Shared`, `Common`, or a domain-specific term. Do not copy the library's
-    internal block names into your project.
+!!! note "The library's block names are its own convention"
+    The library's five internal blocks (`foundation`, `domain`, `application`,
+    `infrastructure`, `presentation`) are an organizational convention, not a
+    naming template.
+    The toolkit itself is architecture-agnostic — you are free to interpret blocks as layers or any other structure.
+    Your own project's blocks should carry names meaningful to your context — `core`, `domain`, or a
+    domain-specific term — rather than replicating the library's internal naming.
 
 ---
 ## Quick summary
@@ -22,8 +24,9 @@ The forging-blocks library is organized into five blocks, each with a distinct r
 
 Dependency rules (inward-pointing): Foundation has no deps → Domain depends on Foundation → Application depends on Domain + Foundation; Infrastructure and Presentation depend on Application + Foundation.
 
-**Block ≠ Layer** — Blocks are architecture-neutral named boundaries within the library; they can be interpreted as layers if that mental model helps.
----
+**Block ≠ Layer**
+
+Blocks are architecture-neutral named boundaries within the library; they can be interpreted as layers if that mental model helps.
 
 The library's five blocks and their dependency relationships:
 

--- a/docs/guide/library-structure.md
+++ b/docs/guide/library-structure.md
@@ -3,6 +3,12 @@
 
 This section describes how **forging-blocks itself** is structured into blocks — named groups of code sharing a responsibility and boundary. It documents the library's own internal organization, not a prescription for how you should structure your project.
 
+!!! warning "Foundation is not a canonical block name"
+    "Foundation" is the library's own term for its innermost, zero-dependency block.
+    Your own project's innermost block should carry a name meaningful to your domain —
+    `Core`, `Shared`, `Common`, or a domain-specific term. Do not copy the library's
+    internal block names into your project.
+
 ---
 ## Quick summary
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ ForgingBlocks helps you shape software that is **clear**, **testable**, and **ma
 ## Learn More
 
 - [Getting Started](guide/getting-started.md)
-- [Blocks Overview](guide/recommended_blocks_structure.md)
+- [Library Structure](guide/library-structure.md)
 - [Organizing Your Project](guide/principles.md)
 - [Reference Index](reference/index.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ nav:
       - Examples: guide/examples.md
       - Principles: guide/principles.md
       - Architecture Overview: guide/architecture-overview.md
-      - Recommended Blocks Structure: guide/recommended_blocks_structure.md
+      - Library Structure: guide/library-structure.md
 
   - Reference:
       - Overview: reference/index.md


### PR DESCRIPTION
- **docs: replace recommended_blocks_structure to library-structure**
- **docs(guide): rename to library-structure.md and add Foundation naming guard**
- **docs: update Blocks Overview link to Library Structure**
- **docs(guide): update Recommended Blocks Structure link to Library Structure**
- **docs(architectural-styles): fill empty Important admonition for Layered Architecture**
- **docs(guide): clarify library block naming conventions are not a template**
